### PR TITLE
feat: Typing presence

### DIFF
--- a/src/components/solid/components/MessageInput.tsx
+++ b/src/components/solid/components/MessageInput.tsx
@@ -19,6 +19,7 @@ import type { Facet } from "@/utils/atproto/rich-text";
 import { generateHash } from "@/utils/generate-hash";
 import { parseZodToErrorOrDisplay } from "@/utils/parse-zod-to-error-or-display";
 import { purify } from "@/utils/purify";
+import { useCommunityContext } from "../contexts/CommunityContext";
 import { useGlobalContext } from "../contexts/GlobalContext";
 import type { AttachmentObj, BlobObj } from "../contexts/GlobalContext/events";
 import { useMessageContext } from "../contexts/MessageContext";
@@ -32,7 +33,6 @@ import {
 	FileFieldTrigger,
 } from "../shadcn-solid/file-field";
 import { TextEditor } from "./TextEditor/TextEditor";
-import { useCommunityContext } from "../contexts/CommunityContext";
 
 const uploadWithProgress = (
 	file: File,

--- a/src/components/solid/components/MessageInput.tsx
+++ b/src/components/solid/components/MessageInput.tsx
@@ -7,7 +7,10 @@ import {
 	type Component,
 	createEffect,
 	createSignal,
+	For,
+	Match,
 	Show,
+	Switch,
 } from "solid-js";
 import { toast } from "somoto";
 import type { PostMessageInput } from "@/actions/message/post";
@@ -29,6 +32,7 @@ import {
 	FileFieldTrigger,
 } from "../shadcn-solid/file-field";
 import { TextEditor } from "./TextEditor/TextEditor";
+import { useCommunityContext } from "../contexts/CommunityContext";
 
 const uploadWithProgress = (
 	file: File,
@@ -96,6 +100,7 @@ export const MessageInput: Component<{
 	const channel = () => params.channel!;
 	const fileField = useFileFieldContext();
 
+	const community = useCommunityContext()!;
 	const [messageData, { clearReplyingTo, triggerScrollToBottom }] =
 		useMessageContext();
 	const [globalData, { addPendingMessage, removePendingMessage }] =
@@ -238,6 +243,29 @@ export const MessageInput: Component<{
 					>
 						<Icon variant="regular" name="x-circle-icon" />
 					</button>
+				</div>
+			</Show>
+			<Show when={globalData.typing.length > 0}>
+				<div class="w-full px-4 py-2 text-xs text-foreground flex items-center gap-1 border-t border-border">
+					<For each={globalData.typing}>
+						{(item, i) => (
+							<span>
+								<Show when={i() > 0}>, </Show>
+								{community.members().find((x) => x.member_did === item.did)
+									?.display_name ??
+									community.members().find((x) => x.member_did === item.did)
+										?.handle}
+							</span>
+						)}
+					</For>
+					<Switch>
+						<Match when={globalData.typing.length === 1}>
+							<span> is typing...</span>
+						</Match>
+						<Match when={globalData.typing.length > 1}>
+							<span> are typing...</span>
+						</Match>
+					</Switch>
 				</div>
 			</Show>
 			<Show

--- a/src/components/solid/components/TextEditor/TextEditor.tsx
+++ b/src/components/solid/components/TextEditor/TextEditor.tsx
@@ -31,6 +31,8 @@ import {
 import { EMOJI_DATA } from "../RichTextRenderer/emojiData";
 import { buildSuggestions } from "./build-suggestions";
 import { proseMirrorToFacets } from "./prosemirror-to-facets";
+import { useGlobalContext } from "../../contexts/GlobalContext";
+import { useParams } from "@solidjs/router";
 
 const CHARACTER_LIMIT = 2048;
 const CIRCUMFERENCE = 2 * Math.PI * 8;
@@ -47,6 +49,10 @@ export const TextEditor: Component<{
 }> = (props) => {
 	let ref!: HTMLDivElement;
 
+	const params = useParams();
+	const channel = () => params.channel!;
+
+	const [, { sendSocketMessage }] = useGlobalContext();
 	const communityContext = useCommunityContext();
 	const channelContext = useChannelContext();
 
@@ -334,6 +340,11 @@ export const TextEditor: Component<{
 				id="editor"
 				class="w-full max-w-[calc(100%-28px)]"
 				onKeyDown={(e) => {
+					sendSocketMessage({
+						action: "typing",
+						channel: channel(),
+					});
+
 					if (e.ctrlKey && e.key === "s") {
 						e.stopImmediatePropagation();
 						e.stopPropagation();

--- a/src/components/solid/components/TextEditor/TextEditor.tsx
+++ b/src/components/solid/components/TextEditor/TextEditor.tsx
@@ -15,12 +15,14 @@ import { CharacterCount, Placeholder, UndoRedo } from "@tiptap/extensions";
 import { type Component, createEffect, createSignal, untrack } from "solid-js";
 import { createEditorTransaction, createTiptapEditor } from "solid-tiptap";
 import "./TextEditor.css";
+import { useParams } from "@solidjs/router";
 import { type Editor, mergeAttributes } from "@tiptap/core";
 import twemoji from "@twemoji/api";
 import type { Facet } from "@/utils/atproto/rich-text";
 import { htmlToDOMOutputSpec } from "@/utils/html-to-dom-output-spec";
 import { useChannelContext } from "../../contexts/ChannelContext";
 import { useCommunityContext } from "../../contexts/CommunityContext";
+import { useGlobalContext } from "../../contexts/GlobalContext";
 import Icon from "../../icons/Icon";
 import {
 	Tooltip,
@@ -31,8 +33,6 @@ import {
 import { EMOJI_DATA } from "../RichTextRenderer/emojiData";
 import { buildSuggestions } from "./build-suggestions";
 import { proseMirrorToFacets } from "./prosemirror-to-facets";
-import { useGlobalContext } from "../../contexts/GlobalContext";
-import { useParams } from "@solidjs/router";
 
 const CHARACTER_LIMIT = 2048;
 const CIRCUMFERENCE = 2 * Math.PI * 8;

--- a/src/components/solid/contexts/GlobalContext/GlobalContext.tsx
+++ b/src/components/solid/contexts/GlobalContext/GlobalContext.tsx
@@ -62,6 +62,7 @@ export const GlobalContextProvider: ParentComponent<{
 		// TODO(app): This might not reflect the user's preferred state.
 		userOnlineStates: [{ did: props.contextData.user.sub, state: "online" }],
 		knownVoiceChannelStates: [],
+		typing: [],
 	});
 
 	const context: [GlobalContextData, GlobalContextUtility] = [
@@ -293,6 +294,44 @@ export const GlobalContextProvider: ParentComponent<{
 					]);
 				}
 			},
+			handleUserTyping(data) {
+				if (data.did === context[0].user.sub) return;
+
+				const existingUserIndex = context[0].typing.findIndex(
+					(x) => x.did === data.did,
+				);
+
+				const cb = () => {
+					setGlobalContext("typing", (current) =>
+						current.filter((x) => x.did !== data.did),
+					);
+				};
+
+				if (existingUserIndex >= 0) {
+					setGlobalContext("typing", (current) => {
+						const existing = current.find((x) => x.did === data.did);
+						if (existing) clearTimeout(existing.timeout);
+						return current.map((x) =>
+							x.did === data.did
+								? {
+										timeout: setTimeout(cb, 3000),
+										did: data.did,
+										channel: data.channel,
+									}
+								: x,
+						);
+					});
+				} else {
+					setGlobalContext("typing", (current) => [
+						...current,
+						{
+							timeout: setTimeout(cb, 3000),
+							did: data.did,
+							channel: data.channel,
+						},
+					]);
+				}
+			},
 		},
 	];
 
@@ -387,10 +426,15 @@ export const GlobalContextProvider: ParentComponent<{
 			case "voice_channel_updated":
 				context[1].processVoiceChannelUpdate(data);
 				break;
+			case "user_typing":
+				// Add user to list, start countdown for 3 seconds, reset countdown if user types again
+				context[1].handleUserTyping(data);
+				console.log(data);
+				break;
 			case "ack":
 				break;
 			default:
-				console.error("Unknown event: ", data);
+				console.warn("Unknown event: ", data);
 		}
 	});
 

--- a/src/components/solid/contexts/GlobalContext/events.ts
+++ b/src/components/solid/contexts/GlobalContext/events.ts
@@ -177,6 +177,12 @@ export type VoiceChannelUpdatedEvent = {
 	member_dids: Array<string>;
 };
 
+export type UserTypingEvent = {
+	type: "user_typing";
+	did: string;
+	channel: string;
+};
+
 export type AppviewSubscriptionData =
 	| AckEvent
 	| MessagePostEvent
@@ -194,7 +200,8 @@ export type AppviewSubscriptionData =
 	| MemberLeftEvent
 	| UserStatusChangedEvent
 	| UserProfileUpdatedEvent
-	| VoiceChannelUpdatedEvent;
+	| VoiceChannelUpdatedEvent
+	| UserTypingEvent;
 
 export type ReactionEventCallback = (
 	data: ReactionAddedEvent | ReactionRemovedEvent,

--- a/src/components/solid/contexts/GlobalContext/types.ts
+++ b/src/components/solid/contexts/GlobalContext/types.ts
@@ -12,6 +12,7 @@ import type {
 	UserOnlineState,
 	UserProfileUpdatedEvent,
 	UserStatusChangedEvent,
+	UserTypingEvent,
 	VoiceChannelUpdatedEvent,
 } from "./events";
 
@@ -46,6 +47,7 @@ export type GlobalContextData = {
 	memberStatusOverrides: Array<UserStatusChangedEvent>;
 	userOnlineStates: Array<OnlineStateInfo>;
 	knownVoiceChannelStates: Array<VoiceChannelUpdatedEvent>;
+	typing: Array<{ timeout: NodeJS.Timeout; did: string; channel: string }>;
 };
 
 export type GlobalContextUtility = {
@@ -76,4 +78,5 @@ export type GlobalContextUtility = {
 	clearMemberOverrides: () => void;
 	updateUserOnlineState: (state: OnlineStateInfo) => void;
 	processVoiceChannelUpdate: (data: VoiceChannelUpdatedEvent) => void;
+	handleUserTyping: (data: UserTypingEvent) => void;
 };


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Currently, users cannot see when another user is typing in a channel they are currently viewing. This can lead to spammy behavior in a conversation and uncertainty between users.

### 📚 Description

This PR adds a typing presence indicator that shows the name of the user currently typing out a message above the message input.