### PR TITLE
fix: Date separator display logic

### DIFF
--- a/src/components/solid/views/ChannelView.tsx
+++ b/src/components/solid/views/ChannelView.tsx
@@ -356,11 +356,15 @@ const ChannelView: Component = () => {
 						const idx = index();
 
 						const isOnNewDay = () => {
-							return (
-								idx !== 0 &&
-								new Date(msgs[idx - 1]?.created_at).getDay() !==
-									new Date(item.created_at).getDay()
-							);
+							if (idx === 0) return false;
+
+							const prevDate = new Date(msgs[idx - 1]?.created_at);
+							const itemDate = new Date(item.created_at);
+
+							const prevDateStr = `${prevDate.getDay()}.${prevDate.getMonth()}.${prevDate.getFullYear()}`;
+							const itemDateStr = `${itemDate.getDay()}.${itemDate.getMonth()}.${itemDate.getFullYear()}`;
+
+							return prevDateStr !== itemDateStr;
 						};
 
 						const hasSubsequent = () => {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Previously, date separators should be displayed whenever a message was sent on a date different to the last message. However, this logic failed in some cases.

### 📚 Description

This PR fixes the logic issue to ensure date lines display correctly. Instead of relying on the day of the week, a string is constructed that contains the day, month and year, which is then compared to the next message.