### PR TITLE
fix: Sidebars don't scroll properly

### DIFF
--- a/src/components/solid/components/Community/ChannelList.tsx
+++ b/src/components/solid/components/Community/ChannelList.tsx
@@ -354,7 +354,7 @@ export const ChannelList: Component<{
 			collisionDetector={collisionDetector}
 		>
 			<DragDropSensors />
-			<nav class="w-full h-full flex flex-col">
+			<nav class="w-full h-full flex flex-col overflow-auto pb-4">
 				<SortableProvider ids={visibleCategories().map((c) => c.rkey)}>
 					<For each={visibleCategories()}>
 						{(category) => (

--- a/src/components/solid/layouts/AppLayout.tsx
+++ b/src/components/solid/layouts/AppLayout.tsx
@@ -239,11 +239,11 @@ const AppLayout: ParentComponent = (props) => {
 			</div>
 			<div class="flex h-[calc(100%-40px)] w-full">
 				<aside class="flex flex-col h-full w-14 p-2 pb-3">
-					<nav class="w-full h-full flex flex-col gap-2">
-						<div class="w-full h-full flex flex-col gap-2">
+					<nav class="w-full h-full flex flex-col gap-2 max-h-[calc(100%-3.25rem-1px)] mb-3.25">
+						<div class="w-full h-full flex flex-col no-scrollbar gap-2 overflow-auto">
 							<A
 								href="/"
-								class="w-10 flex h-10 rounded-md bg-muted hover:bg-primary hover:text-primary-foreground items-center justify-center cursor-pointer"
+								class="min-w-10 flex min-h-10 rounded-md bg-muted hover:bg-primary hover:text-primary-foreground items-center justify-center cursor-pointer"
 							>
 								<Icon variant="regular" name="house-icon" />
 							</A>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -359,3 +359,13 @@
 .emoji-render {
 	font-variant-emoji: emoji;
 }
+
+@layer utilities {
+	.no-scrollbar::-webkit-scrollbar {
+		display: none; /* Chrome, Safari, and Opera */
+	}
+	.no-scrollbar {
+		-ms-overflow-style: none; /* IE and Edge */
+		scrollbar-width: none; /* Firefox */
+	}
+}


### PR DESCRIPTION
### 🔗 Linked issue

Closes #35 

### 🧭 Context

Previously, both the community list and channel list would not properly show scrollbars and be scrollable when there were too many channels or communities present.

### 📚 Description

This PR makes a few CSS adjustments to allow the channel and community lists to overflow properly.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to Colibri!
----------------------------------------------------------------------->
