### PR TITLE
fix: Padding issues on Android devices

### DIFF
--- a/.changeset/curvy-humans-do.md
+++ b/.changeset/curvy-humans-do.md
@@ -1,0 +1,8 @@
+---
+"@colibri-social/website": patch
+"@colibri-social/client": patch
+"@colibri-social/standard-renderer": patch
+"@colibri-social/wrapper": patch
+---
+
+fix: Padding issues on Android devices

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -34,7 +34,7 @@ const {
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="Colibri" />
 		<link rel="manifest" href="/site.webmanifest" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, viewport-fit=cover" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 		<meta name="description" content={description} />

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -129,7 +129,11 @@ const App: ParentComponent = () => {
 							when={isMobile()}
 							fallback={<Toaster richColors position="bottom-right" />}
 						>
-							<Toaster richColors position="top-center" />
+							<Toaster
+								richColors
+								position="top-center"
+								offset="max(32px,var(--safe-area-top))"
+							/>
 						</Show>
 						<SentryRouter root={RootLayout} base="/">
 							<Route path="/" component={RedirectToApp} />

--- a/packages/client/src/components/LoginScreen.tsx
+++ b/packages/client/src/components/LoginScreen.tsx
@@ -84,7 +84,7 @@ export const LoginScreen: Component = () => {
 	});
 
 	return (
-		<section class="pt-[min(10rem,12vh)] mx-auto w-full max-w-336 md:px-16 px-6 relative flex flex-col items-center gap-8 h-screen animate-in fade-in-0 slide-in-from-bottom-2 duration-500 motion-reduce:animate-none">
+		<section class="pt-[calc(min(10rem,12vh)+var(--safe-area-top))] pb-[var(--safe-area-bottom)] mx-auto w-full max-w-336 md:px-16 px-6 relative flex flex-col items-center gap-8 h-screen animate-in fade-in-0 slide-in-from-bottom-2 duration-500 motion-reduce:animate-none">
 			<div class="flex flex-col gap-4 items-center text-center">
 				<small class="text-primary text-sm">Welcome back.</small>
 				<h1 class="text-5xl font-black m-0">SIGN IN</h1>

--- a/packages/client/src/components/RegisterScreen.tsx
+++ b/packages/client/src/components/RegisterScreen.tsx
@@ -127,7 +127,7 @@ export const RegisterScreen: Component = () => {
 	});
 
 	return (
-		<section class="pt-[min(10rem,12vh)] pb-8 mx-auto w-full max-w-336 md:px-16 px-6 relative flex flex-col items-center gap-8 min-h-screen animate-in fade-in-0 slide-in-from-bottom-2 duration-500 motion-reduce:animate-none">
+		<section class="pt-[calc(min(10rem,12vh)+var(--safe-area-top))] pb-[calc(2rem+var(--safe-area-bottom))] mx-auto w-full max-w-336 md:px-16 px-6 relative flex flex-col items-center gap-8 min-h-screen animate-in fade-in-0 slide-in-from-bottom-2 duration-500 motion-reduce:animate-none">
 			<div class="flex flex-col gap-4 items-center text-center">
 				<small class="text-primary text-sm">Join Colibri.</small>
 				<h1 class="text-5xl font-black m-0">CREATE ACCOUNT</h1>

--- a/packages/client/src/components/app/VoiceOverlay.tsx
+++ b/packages/client/src/components/app/VoiceOverlay.tsx
@@ -46,6 +46,30 @@ const WIDTH_KEY = "colibri:voice-overlay-width";
 const clamp = (v: number, lo: number, hi: number): number =>
 	Math.max(lo, Math.min(hi, v));
 
+type Insets = { top: number; bottom: number; left: number; right: number };
+
+const readSafeInsets = (): Insets => {
+	if (typeof document === "undefined")
+		return { top: 0, bottom: 0, left: 0, right: 0 };
+	const probe = document.createElement("div");
+	probe.style.cssText =
+		"position:fixed;visibility:hidden;pointer-events:none;padding-top:var(--safe-area-top);padding-bottom:var(--safe-area-bottom);padding-left:var(--safe-area-left);padding-right:var(--safe-area-right);";
+	document.body.appendChild(probe);
+	const cs = getComputedStyle(probe);
+	const px = (v: string): number => {
+		const n = Number.parseFloat(v);
+		return Number.isFinite(n) ? n : 0;
+	};
+	const insets: Insets = {
+		top: px(cs.paddingTop),
+		bottom: px(cs.paddingBottom),
+		left: px(cs.paddingLeft),
+		right: px(cs.paddingRight),
+	};
+	probe.remove();
+	return insets;
+};
+
 const loadCorner = (): Corner => {
 	const raw = localStorage.getItem(CORNER_KEY);
 	return raw === "tl" || raw === "tr" || raw === "bl" || raw === "br"
@@ -207,11 +231,16 @@ export const VoiceOverlay: Component = () => {
 	const [vp, setVp] = createSignal({
 		w: window.innerWidth,
 		h: window.innerHeight,
+		insets: readSafeInsets(),
 	});
 
 	onMount(() => {
 		const onResizeWindow = () =>
-			setVp({ w: window.innerWidth, h: window.innerHeight });
+			setVp({
+				w: window.innerWidth,
+				h: window.innerHeight,
+				insets: readSafeInsets(),
+			});
 		window.addEventListener("resize", onResizeWindow);
 		onCleanup(() => window.removeEventListener("resize", onResizeWindow));
 	});
@@ -222,10 +251,16 @@ export const VoiceOverlay: Component = () => {
 	let boxRef: HTMLDivElement | undefined;
 
 	const restPos = (): { x: number; y: number } => {
-		const { w: vw, h: vh } = vp();
+		const { w: vw, h: vh, insets } = vp();
 		const c = corner();
-		const left = c === "tl" || c === "bl" ? MARGIN : vw - MARGIN - width();
-		const top = c === "tl" || c === "tr" ? MARGIN : vh - MARGIN - height();
+		const left =
+			c === "tl" || c === "bl"
+				? MARGIN + insets.left
+				: vw - MARGIN - insets.right - width();
+		const top =
+			c === "tl" || c === "tr"
+				? MARGIN + insets.top
+				: vh - MARGIN - insets.bottom - height();
 		return { x: left, y: top };
 	};
 
@@ -249,9 +284,10 @@ export const VoiceOverlay: Component = () => {
 
 		if (Math.abs(dx) > 3 || Math.abs(dy) > 3) moved = true;
 
+		const { w: vw, h: vh, insets } = vp();
 		setDrag({
-			x: clamp(moveState.x + dx, 0, vp().w - width()),
-			y: clamp(moveState.y + dy, 0, vp().h - height()),
+			x: clamp(moveState.x + dx, insets.left, vw - insets.right - width()),
+			y: clamp(moveState.y + dy, insets.top, vh - insets.bottom - height()),
 		});
 	};
 

--- a/packages/client/src/components/app/channel/message/DebugInfo.tsx
+++ b/packages/client/src/components/app/channel/message/DebugInfo.tsx
@@ -37,7 +37,7 @@ export const DebugInfo: Component = () => {
 			}
 		>
 			<BottomSheet open={debugModalOpen()} onOpenChange={setDebugModalOpen}>
-				<div class="overflow-y-auto pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+				<div class="overflow-y-auto pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<SettingsInfoPage uri={message.uri} />
 				</div>
 			</BottomSheet>

--- a/packages/client/src/components/app/common/ComposerMediaPickers.tsx
+++ b/packages/client/src/components/app/common/ComposerMediaPickers.tsx
@@ -89,7 +89,7 @@ export const ComposerMediaPickers: Component<{
 				<SmileyIcon width={20} height={20} />
 			</button>
 			<BottomSheet open={drawerOpen()} onOpenChange={setDrawerOpen}>
-				<div class="flex flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+				<div class="flex flex-col px-3 pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<Show when={drawerOpen()}>
 						<Tabs
 							value={tab()}

--- a/packages/client/src/components/app/common/EmojiPopover.tsx
+++ b/packages/client/src/components/app/common/EmojiPopover.tsx
@@ -163,7 +163,7 @@ export const EmojiPopover: ParentComponent<{
 				open={props.emojiPopoverOpen()}
 				onOpenChange={props.setEmojiPopoverOpen}
 			>
-				<div class="flex flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+				<div class="flex flex-col px-3 pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<EmojiPickerBody onEmoji={handleEmoji} />
 				</div>
 			</BottomSheet>

--- a/packages/client/src/components/app/common/GifPopover.tsx
+++ b/packages/client/src/components/app/common/GifPopover.tsx
@@ -388,7 +388,7 @@ export const GifPopover: ParentComponent<{
 				</div>
 			</Show>
 			<BottomSheet open={props.open()} onOpenChange={props.setOpen}>
-				<div class="flex flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+				<div class="flex flex-col px-3 pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<Show when={props.open()}>
 						<GifPickerBody onSelect={handleSelect} />
 					</Show>

--- a/packages/client/src/components/app/common/SettingsModal.tsx
+++ b/packages/client/src/components/app/common/SettingsModal.tsx
@@ -51,7 +51,7 @@ export const SettingsPage: ParentComponent<{
 				</div>
 			</div>
 			<Show when={props.onSave || props.onReset}>
-				<div class="w-full border-t border-border p-4 flex flex-row items-center justify-end gap-2 h-16 bg-background rounded-br-xl">
+				<div class="w-full border-t border-border px-4 pt-4 pb-[calc(1rem+var(--safe-area-bottom))] flex flex-row items-center justify-end gap-2 min-h-16 bg-background rounded-br-xl">
 					<Show when={props.canReset && props.onReset}>
 						<Button
 							variant="secondary"

--- a/packages/client/src/components/app/community/RoleMentionPopover.tsx
+++ b/packages/client/src/components/app/community/RoleMentionPopover.tsx
@@ -110,7 +110,7 @@ export const RoleMentionPopover: ParentComponent<{
 				handleOverlay
 				class="overflow-hidden"
 			>
-				<div class="min-h-0 overflow-y-auto">
+				<div class="min-h-0 overflow-y-auto pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<RolePopoverContents class="w-full" role={props.role} />
 				</div>
 			</BottomSheet>

--- a/packages/client/src/components/app/onboarding/RecordBootstrapModal.tsx
+++ b/packages/client/src/components/app/onboarding/RecordBootstrapModal.tsx
@@ -213,7 +213,7 @@ export function RecordBootstrapModal<T>(props: {
 		<Dialog open={props.open} onOpenChange={handleOpenChange}>
 			<DialogPortal>
 				<DialogContent
-					class="sm:max-w-2xl max-h-[calc(100svh-2rem)] overflow-auto"
+					class="sm:max-w-2xl max-h-[calc(100svh-2rem-var(--safe-area-top)-var(--safe-area-bottom))] overflow-auto"
 					showCloseButton={dismissible()}
 				>
 					<DialogHeader>

--- a/packages/client/src/components/app/user/ProfilePopover.tsx
+++ b/packages/client/src/components/app/user/ProfilePopover.tsx
@@ -362,7 +362,7 @@ export const ProfilePopover: ParentComponent<{
 				handleOverlay
 				class="overflow-hidden"
 			>
-				<div class="min-h-0 overflow-y-auto">
+				<div class="min-h-0 overflow-y-auto pb-[calc(0.75rem+var(--safe-area-bottom))]">
 					<ProfilePopoverContents class="w-full" user={props.user} />
 				</div>
 			</BottomSheet>

--- a/packages/client/src/components/ui/Dialog.tsx
+++ b/packages/client/src/components/ui/Dialog.tsx
@@ -55,7 +55,7 @@ export const DialogContent = <T extends ValidComponent = "div">(
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				class={cx(
-					"bg-background data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					"bg-background data-[expanded]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[expanded]:fade-in-0 data-[closed]:zoom-out-95 data-[expanded]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-var(--safe-area-top)-var(--safe-area-bottom)-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 					props.class,
 				)}
 				{...rest}

--- a/packages/client/src/components/ui/MenuDrawer.tsx
+++ b/packages/client/src/components/ui/MenuDrawer.tsx
@@ -191,7 +191,7 @@ export const MenuDrawer = (props: MenuDrawerProps) => {
 					</span>
 				</div>
 			</Show>
-			<div class="flex flex-col gap-0.5 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] overflow-y-auto">
+			<div class="flex flex-col gap-0.5 px-2 pb-[calc(0.5rem+var(--safe-area-bottom))] overflow-y-auto">
 				{props.children}
 			</div>
 		</BottomSheet>

--- a/packages/client/src/components/ui/ResponsiveDialog.tsx
+++ b/packages/client/src/components/ui/ResponsiveDialog.tsx
@@ -74,7 +74,7 @@ export const ResponsiveDialog = (props: ResponsiveDialogProps) => {
 								</DrawerLabel>
 							</DrawerHeader>
 						</Show>
-						<div class="flex flex-col gap-4 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+						<div class="flex flex-col gap-4 overflow-y-auto px-4 pb-[calc(1rem+var(--safe-area-bottom))]">
 							{props.children}
 						</div>
 					</DrawerContent>

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -14,6 +14,8 @@
 	--font-geist-mono: "Geist Mono", "Geist Mono Fallback", sans-serif;
 	--font-hanken-grotesk:
 		"Hanken Grotesk", "Hanken Grotesk Fallback", sans-serif;
+	--safe-area-top: env(safe-area-inset-top);
+	--safe-area-bottom: env(safe-area-inset-bottom);
 }
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/client/src/layouts/AppLayout.tsx
+++ b/packages/client/src/layouts/AppLayout.tsx
@@ -261,6 +261,13 @@ const AppLayout: ParentComponent = (props) => {
 			? `${viewport.height()}px`
 			: undefined;
 
+	const keyboardOpen = () => {
+		const h = viewport.height();
+		if (!isMobile() || h === undefined || typeof document === "undefined")
+			return false;
+		return document.documentElement.clientHeight - h > 100;
+	};
+
 	onMount(() => {
 		let pending: string | null = null;
 		try {
@@ -430,6 +437,8 @@ const AppLayout: ParentComponent = (props) => {
 			classList={{
 				"h-[100dvh]": isMobile() && shellHeight() === undefined,
 				"h-screen": !isMobile(),
+				"pt-[var(--safe-area-top)]": isMobile(),
+				"pb-[var(--safe-area-bottom)]": isMobile() && !keyboardOpen(),
 			}}
 			style={{
 				...(shellHeight() ? { height: shellHeight() } : {}),
@@ -456,7 +465,7 @@ const AppLayout: ParentComponent = (props) => {
 				</div>
 			</div>
 			<div
-				class="flex w-full"
+				class="flex w-full relative"
 				classList={{
 					"h-full": isMobile() || isTauriRuntime(),
 					"h-[calc(100%-40px)]": !isMobile() && !isTauriRuntime(),

--- a/packages/client/src/layouts/CommunityLayout.tsx
+++ b/packages/client/src/layouts/CommunityLayout.tsx
@@ -197,8 +197,7 @@ const CommunityLayout: ParentComponent = (props) => {
 		<div
 			class="bg-background w-full h-full flex relative overflow-clip"
 			classList={{
-				"rounded-tl-xl border-t border-l border-border":
-					!isMobile() && !isTauriRuntime(),
+				"rounded-tl-xl border-t border-l border-border": !isMobile(),
 			}}
 		>
 			<aside

--- a/packages/standard-renderer/.gitignore
+++ b/packages/standard-renderer/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo

--- a/packages/wrapper/index.html
+++ b/packages/wrapper/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta
 			name="viewport"
-			content="width=device-width, initial-scale=1, interactive-widget=resizes-content"
+			content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
 		/>
 		<meta name="theme-color" content="#000000" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/packages/wrapper/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/packages/wrapper/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,20 @@
                 <data android:scheme="social.colibri.next" />
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
-            
+            <intent-filter >
+                <action android:name="android.intent.action.VIEW" />
+                <!-- ChromeOS ARC++ uses a different action for deep links -->
+                <action android:name="org.chromium.arc.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="social.colibri" />
+                <data android:scheme="social.colibri.next" />
+                
+                
+                
+                
+                
+            </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
 

--- a/packages/wrapper/src-tauri/gen/android/app/src/main/java/social/colibri/app/MainActivity.kt
+++ b/packages/wrapper/src-tauri/gen/android/app/src/main/java/social/colibri/app/MainActivity.kt
@@ -1,11 +1,55 @@
 package social.colibri.app
 
+import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebView
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 
 class MainActivity : TauriActivity() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var lastBars: Insets = Insets.NONE
+
   override fun onCreate(savedInstanceState: Bundle?) {
-    enableEdgeToEdge()
+    enableEdgeToEdge(
+      statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+      navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+    )
     super.onCreate(savedInstanceState)
+  }
+
+  override fun onWebViewCreate(webView: WebView) {
+    ViewCompat.setOnApplyWindowInsetsListener(webView) { _, insets ->
+      lastBars = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      )
+      injectInsets(webView, lastBars)
+      insets
+    }
+    ViewCompat.requestApplyInsets(webView)
+    for (delay in longArrayOf(250L, 750L, 1500L, 3000L)) {
+      handler.postDelayed({ injectInsets(webView, lastBars) }, delay)
+    }
+  }
+
+  private fun injectInsets(webView: WebView, bars: Insets) {
+    val d = webView.resources.displayMetrics.density
+    webView.evaluateJavascript(
+      """
+      (function () {
+        var s = document.documentElement.style;
+        s.setProperty('--safe-area-top', '${bars.top / d}px');
+        s.setProperty('--safe-area-bottom', '${bars.bottom / d}px');
+        s.setProperty('--safe-area-left', '${bars.left / d}px');
+        s.setProperty('--safe-area-right', '${bars.right / d}px');
+      })();
+      """.trimIndent(),
+      null,
+    )
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #51 

### 🧭 Context

Android phones were missing some padding, see #51.

### 📚 Description

Fixes padding on compatible devices by checking `env(safe-area-inset-*)`. As a fallback, the Android builds do a manual calculation.