### PR TITLE
fix: Better settings drawer appearance on mobile

### DIFF
--- a/.changeset/giant-dancers-grab.md
+++ b/.changeset/giant-dancers-grab.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Swaps the mobile settings drawer select chevron to an SVG controlled by us and hides the duplicate title.

--- a/packages/client/src/components/app/common/SettingsModal.tsx
+++ b/packages/client/src/components/app/common/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
 	Switch,
 } from "solid-js";
 import { Dynamic } from "solid-js/web";
+import CaretDownIcon from "~icons/ph/caret-down";
 import XIcon from "~icons/ph/x";
 import { cx } from "../../../utils/cva";
 import { useIsMobile } from "../../../utils/mobile-pane";
@@ -37,14 +38,24 @@ export const SettingsPage: ParentComponent<{
 	canReset?: boolean;
 	onReset?: () => void;
 }> = (props) => {
+	const isMobile = useIsMobile();
 	return (
 		<div class="w-full flex flex-col h-auto relative max-h-144">
-			<div class="px-4 py-4 border-b border-border h-auto">
-				<h2 class="m-0">{props.title}</h2>
-				<Show when={props.description}>
-					<span class="text-sm leading-5 block mt-2">{props.description}</span>
-				</Show>
-			</div>
+			<Show when={!isMobile() || props.description}>
+				<div class="px-4 py-4 border-b border-border h-auto">
+					<Show when={!isMobile()}>
+						<h2 class="m-0">{props.title}</h2>
+					</Show>
+					<Show when={props.description}>
+						<span
+							class="text-sm leading-5 block"
+							classList={{ "mt-2": !isMobile() }}
+						>
+							{props.description}
+						</span>
+					</Show>
+				</div>
+			</Show>
 			<div class="flex flex-col gap-4 w-full flex-1 min-h-0">
 				<div class="w-full flex flex-col gap-4 px-4 lg:max-w-137 h-full overflow-auto py-4">
 					{props.children}
@@ -230,33 +241,36 @@ export const SettingsModal: ParentComponent<{
 				<DrawerPortal>
 					<DrawerContent class="max-h-[92dvh] p-0 overflow-hidden">
 						<div class="p-3 border-b border-border">
-							<select
-								value={activePage()}
-								onChange={(e) => setActivePage(e.currentTarget.value)}
-								class="w-full bg-muted/50 border border-border rounded-md px-3 py-2 text-base"
-							>
-								<For each={props.pages}>
-									{(item) => (
-										<Show when={item.visible?.() !== false}>
-											<option value={item.id}>{item.title}</option>
-										</Show>
-									)}
-								</For>
-								<Show when={props.debugPage}>
-									<option value={props.debugPage!.id}>
-										{props.debugPage!.title}
-									</option>
-								</Show>
-								<Show
-									when={
-										props.dangerPage && props.dangerPage.visible?.() !== false
-									}
+							<div class="relative">
+								<select
+									value={activePage()}
+									onChange={(e) => setActivePage(e.currentTarget.value)}
+									class="w-full appearance-none bg-muted/50 border border-border rounded-md pl-3 pr-9 py-2 text-base"
 								>
-									<option value={props.dangerPage!.id}>
-										{props.dangerPage!.title}
-									</option>
-								</Show>
-							</select>
+									<For each={props.pages}>
+										{(item) => (
+											<Show when={item.visible?.() !== false}>
+												<option value={item.id}>{item.title}</option>
+											</Show>
+										)}
+									</For>
+									<Show when={props.debugPage}>
+										<option value={props.debugPage!.id}>
+											{props.debugPage!.title}
+										</option>
+									</Show>
+									<Show
+										when={
+											props.dangerPage && props.dangerPage.visible?.() !== false
+										}
+									>
+										<option value={props.dangerPage!.id}>
+											{props.dangerPage!.title}
+										</option>
+									</Show>
+								</select>
+								<CaretDownIcon class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+							</div>
 						</div>
 						<div
 							class="flex-1 min-h-0 overflow-y-auto"


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #67 

### 🧭 Context

Currently our settings drawer appearance on mobile uses the native select chevron and displays the heading below the select input.

### 📚 Description

This PR swaps the native chevron out for our SVG variant and makes the title hidden on mobile so the select acts as the title.