### PR TITLE
fix: Properly pin chat viewport to bottom

### DIFF
--- a/.changeset/tame-otters-flow.md
+++ b/.changeset/tame-otters-flow.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+fix: Channel now scrolls to the latest message when opening it for the first time on mobile

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -38,6 +38,7 @@ import { SocketContextProvider } from "./contexts/Socket";
 import { SoundsContextProvider } from "./contexts/Sounds";
 import { UserContextProvider } from "./contexts/User";
 import { UserPreferencesContextProvider } from "./contexts/UserPreferences";
+import { ViewportProvider } from "./contexts/Viewport";
 import { VoiceChatContextProvider } from "./contexts/VoiceChat";
 import AppLayout from "./layouts/AppLayout";
 import ChannelLayoutWithContext from "./layouts/ChannelLayout";
@@ -63,7 +64,9 @@ const AppRoute: ParentComponent = (props) => {
 						<ActorCacheProvider>
 							<SoundsContextProvider>
 								<VoiceChatContextProvider>
-									<AppLayout>{props.children}</AppLayout>
+									<ViewportProvider>
+										<AppLayout>{props.children}</AppLayout>
+									</ViewportProvider>
 								</VoiceChatContextProvider>
 							</SoundsContextProvider>
 						</ActorCacheProvider>

--- a/packages/client/src/contexts/Viewport.tsx
+++ b/packages/client/src/contexts/Viewport.tsx
@@ -1,0 +1,27 @@
+import { createContext, type ParentComponent, useContext } from "solid-js";
+import {
+	createViewportMetrics,
+	type ViewportMetrics,
+} from "../utils/visual-viewport";
+
+export const ViewportContext = createContext<ViewportMetrics>();
+
+export const ViewportProvider: ParentComponent = (props) => {
+	const metrics = createViewportMetrics();
+
+	return (
+		<ViewportContext.Provider value={metrics}>
+			{props.children}
+		</ViewportContext.Provider>
+	);
+};
+
+export const useViewport = (): ViewportMetrics => {
+	const ctx = useContext(ViewportContext);
+
+	if (!ctx) {
+		throw new Error("Unable to get viewport context.");
+	}
+
+	return ctx;
+};

--- a/packages/client/src/layouts/AppLayout.tsx
+++ b/packages/client/src/layouts/AppLayout.tsx
@@ -49,6 +49,7 @@ import {
 } from "../contexts/Notifications";
 import { useSocketContext } from "../contexts/Socket";
 import { useUserContext } from "../contexts/User";
+import { useViewport } from "../contexts/Viewport";
 import { isTauriRuntime } from "../notifications/environment";
 import { LongPressSensors } from "../utils/create-longpress-sensor";
 import {
@@ -57,7 +58,6 @@ import {
 	reorderList,
 } from "../utils/drag";
 import { createMobilePane } from "../utils/mobile-pane";
-import { createViewportMetrics } from "../utils/visual-viewport";
 
 const CommunityAvatar = (props: { item: Community; class?: string }) => {
 	const communityDid = props.item.uri.split("/")[2];
@@ -230,7 +230,7 @@ const AppLayout: ParentComponent = (props) => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { isMobile, currentPane } = createMobilePane();
-	const viewport = createViewportMetrics();
+	const viewport = useViewport();
 
 	const shellHeight = () =>
 		isMobile() && viewport.height() !== undefined

--- a/packages/client/src/layouts/ChannelLayout.tsx
+++ b/packages/client/src/layouts/ChannelLayout.tsx
@@ -44,6 +44,7 @@ import { isSameChannelUri, useNotifications } from "../contexts/Notifications";
 import { ScrollAnchorProvider } from "../contexts/ScrollAnchor";
 import { useUserContext } from "../contexts/User";
 import { useUserPreferences } from "../contexts/UserPreferences";
+import { useViewport } from "../contexts/Viewport";
 import { getChannelParam } from "../utils/get-param";
 import { createMobilePane } from "../utils/mobile-pane";
 
@@ -100,6 +101,7 @@ const ChannelLayout: ParentComponent = (props) => {
 	const mutes = useMutes();
 	const { preferences, toggleMembersVisible } = useUserPreferences();
 	const { isMobile, popPane, pushPane } = createMobilePane();
+	const viewport = useViewport();
 
 	const toggleChannelMute = () => {
 		const channelUri = channel.channelUri();
@@ -177,6 +179,32 @@ const ChannelLayout: ParentComponent = (props) => {
 		wasAtBottom = true;
 	};
 
+	const REPIN_MAX_FRAMES = 20;
+	const REPIN_STABLE_FRAMES = 2;
+
+	const pinToBottomStable = () => {
+		if (!scrollContainer) return;
+		let lastHeight = -1;
+		let stable = 0;
+		let frames = 0;
+		const step = () => {
+			if (!scrollContainer || !wasAtBottom) return;
+			if (scrollBottomBeforeFetch !== null) return;
+			const h = scrollContainer.scrollHeight;
+			scrollContainer.scrollTop = h;
+			wasAtBottom = true;
+			if (h === lastHeight) {
+				stable++;
+			} else {
+				stable = 0;
+				lastHeight = h;
+			}
+			if (stable >= REPIN_STABLE_FRAMES || ++frames >= REPIN_MAX_FRAMES) return;
+			requestAnimationFrame(step);
+		};
+		requestAnimationFrame(step);
+	};
+
 	const observeJumpSentinel = (el: HTMLDivElement) => {
 		if (jumpSentinel && jumpObserver) jumpObserver.unobserve(jumpSentinel);
 		jumpSentinel = el;
@@ -241,8 +269,7 @@ const ChannelLayout: ParentComponent = (props) => {
 			contentResizeObserver = new ResizeObserver(() => {
 				if (!scrollContainer || !didInitialScroll) return;
 				if (scrollBottomBeforeFetch !== null) return; // prepend in progress
-				if (wasAtBottom)
-					scrollContainer.scrollTop = scrollContainer.scrollHeight;
+				if (wasAtBottom) pinToBottomStable();
 			});
 			contentResizeObserver.observe(messagesWrapper);
 		}
@@ -441,13 +468,27 @@ const ChannelLayout: ParentComponent = (props) => {
 			if (node) {
 				node.scrollIntoView({ block: "start" });
 			} else {
-				scrollToBottom();
+				wasAtBottom = true;
+				pinToBottomStable();
 			}
 
 			channel.advanceReadCursor();
 			notifications.markChannelRead(channel.channelUri());
 		});
 	});
+
+	createEffect(
+		on(
+			viewport.height,
+			() => {
+				if (!didInitialScroll || !scrollContainer) return;
+				if (!wasAtBottom) return;
+				if (scrollBottomBeforeFetch !== null) return;
+				pinToBottomStable();
+			},
+			{ defer: true },
+		),
+	);
 
 	createEffect(
 		on(


### PR DESCRIPTION
### 🔗 Linked issue

Closes #68 

### 🧭 Context

When opening a channel on mobile, the messages sometimes spawn in and cause the viewport to not show the latest message (not pinned to the bottom).

### 📚 Description

This PR introduces a new viewport context to ensure the bottom pinning works correctly.
