### PR TITLE
fix: Show data disclaimer for returning users

### DIFF
--- a/.changeset/plain-bags-play.md
+++ b/.changeset/plain-bags-play.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+fix: Show a disclaimer for returning users in the profile setup that their old data is safe

--- a/packages/client/src/components/app/onboarding/ProfileGate.tsx
+++ b/packages/client/src/components/app/onboarding/ProfileGate.tsx
@@ -10,7 +10,11 @@ import { ProfileSetupModal } from "./ProfileSetupModal";
  * indexing lag. If it's missing, the (non-dismissible) {@link ProfileSetupModal}
  * is shown until the user completes setup.
  */
-type GateState = { needsSetup: boolean; hasBluesky: boolean };
+type GateState = {
+	needsSetup: boolean;
+	hasBluesky: boolean;
+	returning: boolean;
+};
 
 export const ProfileGate: ParentComponent = (props) => {
 	const user = useUserContext();
@@ -29,12 +33,27 @@ export const ProfileGate: ParentComponent = (props) => {
 		}
 	};
 
+	// Any `social.colibri.*` record (other than the profile, which we know is
+	// absent when setup is showing) means the account used Colibri before, so we
+	// can reassure them rather than treat them as brand new. Fails safe to false.
+	const isReturning = async (): Promise<boolean> => {
+		try {
+			const res = await user.atproto.agent.com.atproto.repo.describeRepo({
+				repo: user.did,
+			});
+			return res.data.collections.some((c) => c.startsWith("social.colibri."));
+		} catch {
+			return false;
+		}
+	};
+
 	const [gate, { mutate }] = createResource(async (): Promise<GateState> => {
-		const [hasColibri, hasBluesky] = await Promise.all([
+		const [hasColibri, hasBluesky, returning] = await Promise.all([
 			recordExists("social.colibri.actor.profile"),
 			recordExists("app.bsky.actor.profile"),
+			isReturning(),
 		]);
-		return { needsSetup: !hasColibri, hasBluesky };
+		return { needsSetup: !hasColibri, hasBluesky, returning };
 	});
 
 	return (
@@ -46,6 +65,7 @@ export const ProfileGate: ParentComponent = (props) => {
 				<ProfileSetupModal
 					open
 					hasBlueskyProfile={gate()?.hasBluesky ?? false}
+					returning={gate()?.returning ?? false}
 					onComplete={() => mutate((prev) => ({ ...prev!, needsSetup: false }))}
 				/>
 			</Match>

--- a/packages/client/src/components/app/onboarding/ProfileSetupModal.tsx
+++ b/packages/client/src/components/app/onboarding/ProfileSetupModal.tsx
@@ -9,6 +9,7 @@ import {
 	Switch,
 } from "solid-js";
 import ArrowLineLeftIcon from "~icons/ph/arrow-line-left";
+import InfoIcon from "~icons/ph/info";
 import { putRecord, uploadBlob } from "../../../atproto/pds";
 import { resolveBlob } from "../../../atproto/resolve-blob";
 import { endSession } from "../../../atproto/session";
@@ -289,6 +290,7 @@ const ProfileFieldsForm: Component<{
 export const ProfileSetupModal: Component<{
 	open: boolean;
 	hasBlueskyProfile: boolean;
+	returning: boolean;
 	onComplete: () => void;
 }> = (props) => {
 	const user = useUserContext();
@@ -311,6 +313,17 @@ export const ProfileSetupModal: Component<{
 	const config: RecordBootstrapConfig<ProfileFields> = {
 		title: "Set up your profile",
 		submitLabel: "Create profile",
+		notice: props.returning ? (
+			<div class="flex flex-row items-start gap-3 rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+				<InfoIcon class="mt-0.5 shrink-0 text-primary" />
+				<p class="m-0">
+					<strong class="text-foreground">Welcome back!</strong> Your
+					communities, messages, and account are safe. Colibri now uses its own
+					profile, separate from Bluesky. Set it up below to pick up where you
+					left off. You can import your Bluesky profile or start fresh.
+				</p>
+			</div>
+		) : undefined,
 		footerStart: (
 			<Button variant="ghost" onClick={logout}>
 				<ArrowLineLeftIcon />

--- a/packages/client/src/components/app/onboarding/RecordBootstrapModal.tsx
+++ b/packages/client/src/components/app/onboarding/RecordBootstrapModal.tsx
@@ -92,6 +92,8 @@ export interface RecordBootstrapConfig<T> {
 	/** Persists the record. Receives the final values and the sync choice. */
 	submit: (value: T, opts: { sync: boolean }) => Promise<void>;
 	submitLabel?: string;
+	/** Optional informational callout rendered below the title on every step. */
+	notice?: JSX.Element;
 	/**
 	 * Optional element rendered at the start (left) of every step's footer,
 	 * separated from the primary actions. Useful for secondary actions like
@@ -219,6 +221,7 @@ export function RecordBootstrapModal<T>(props: {
 					<DialogHeader>
 						<h2 class="m-0 text-center">{props.config.title}</h2>
 					</DialogHeader>
+					<Show when={props.config.notice}>{props.config.notice}</Show>
 					<SwitchFlow>
 						<Match when={step() === "choice"}>
 							<div class="flex flex-row items-center justify-center w-full gap-4">


### PR DESCRIPTION
### 🔗 Linked issue

Closes #69 

### 🧭 Context

Starting with the beta, users who open the Colibri app without having a `social.colibri.actor.profile` record will get a setup modal prompting them to create a profile. This led to confusion with users who had previously used Colibri in the Alpha.

### 📚 Description

This PR adds a callout to the profile setup step which tells returning users what happened, why they are seeing this setup screen, and that their data is safe.