### PR TITLE
fix: Homebrew builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,12 +89,14 @@ jobs:
         with:
           workspaces: "packages/wrapper/src-tauri -> target"
 
-      - name: install Apple provisioning profile (macOS only)
-        if: matrix.platform == 'macos-latest'
-        env:
-          MAC_PROVISIONPROFILE: ${{ secrets.MAC_PROVISIONPROFILE }}
-        run: |
-          echo "$MAC_PROVISIONPROFILE" | base64 --decode > packages/wrapper/src-tauri/Colibri_Mac.provisionprofile
+      # TODO(appstore): Only needed for Mac App Store submissions.
+      # Uncomment when producing a MAS build:
+      # - name: install Apple provisioning profile (macOS only)
+      #   if: matrix.platform == 'macos-latest'
+      #   env:
+      #     MAC_PROVISIONPROFILE: ${{ secrets.MAC_PROVISIONPROFILE }}
+      #   run: |
+      #     echo "$MAC_PROVISIONPROFILE" | base64 --decode > packages/wrapper/src-tauri/Colibri_Mac.provisionprofile
 
       - name: install App Store Connect API key (macOS only)
         if: matrix.platform == 'macos-latest'

--- a/packages/wrapper/src-tauri/Cargo.toml
+++ b/packages/wrapper/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ name = "wrapper_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2" }
 
 [features]
 # Sentry is on by default. Disable it (`--no-default-features`, wired to the
@@ -30,7 +30,7 @@ default = ["sentry"]
 sentry = ["dep:sentry"]
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["config-json5"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/wrapper/src-tauri/Entitlements.plist
+++ b/packages/wrapper/src-tauri/Entitlements.plist
@@ -7,11 +7,18 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
+	<!-- TODO(appstore): The following are only needed for Mac App Store submissions
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.application-identifier</key>
 	<string>social.colibri.app</string>
 	<key>com.apple.team-identifier</key>
 	<string>8V8SWK3942</string>
+
+	Also add the following in tauri.conf.json `bundle.macos` for appstore builds only
+	"files": {
+		"embedded.provisionprofile": "./Colibri_Mac.provisionprofile"
+	}
+	-->
 </dict>
 </plist>

--- a/packages/wrapper/src-tauri/tauri.conf.json
+++ b/packages/wrapper/src-tauri/tauri.conf.json
@@ -35,10 +35,7 @@
 			"icons/icon.ico"
 		],
 		"macOS": {
-			"entitlements": "Entitlements.plist",
-			"files": {
-				"embedded.provisionprofile": "./Colibri_Mac.provisionprofile"
-			}
+			"entitlements": "Entitlements.plist"
 		},
 		"category": "SocialNetworking",
 		"publisher": "Colibri",


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Installing Colibri via Homebrew causes MacOS to be unable to open the app.

### 📚 Description

This PR fixes the issue by keeping the provisionprofile and other relevant keys out of the homebrew build.