### PR TITLE
fix: Properly generate Sentry sourcemaps

### DIFF
--- a/.changeset/tidy-tigers-kneel.md
+++ b/.changeset/tidy-tigers-kneel.md
@@ -1,0 +1,6 @@
+---
+"@colibri-social/wrapper": patch
+"@colibri-social/client": patch
+---
+
+Fixes sourcemap generation and adjusts the publish workflow to upload them to Sentry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,6 +183,14 @@ jobs:
           args: ${{ matrix.args }}
           mobile: ${{ matrix.mobile }}
 
+      - name: Upload Rust debug symbols to Sentry
+        if: env.SENTRY_AUTH_TOKEN != ''
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: colibri-social
+          SENTRY_PROJECT: rust-native-app
+        run: pnpm dlx @sentry/cli debug-files upload --include-sources packages/wrapper/src-tauri/target
+
       - name: Route AAB to Play, remove from release (Android only)
         if: matrix.is-android
         env:

--- a/packages/client/tsup.config.ts
+++ b/packages/client/tsup.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
 	format: ["esm"],
 	dts: true,
 	clean: true,
+	sourcemap: true,
 	// Dependencies are externalized by default, opt `@sentry/solid` back into
 	// bundling so the stub redirect below can take effect and the real SDK is
 	// dropped rather than left as an external import

--- a/packages/wrapper/src-tauri/Cargo.toml
+++ b/packages/wrapper/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [profile.release]
 debug = "line-tables-only"
+split-debuginfo = "packed"
 
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Current error traces in Sentry link to our dist directories and compiled files, which makes debugging difficult.

### 📚 Description

This PR enables the sourcemap/debug symbol upload for our native apps.