### PR TITLE
fix: Drawer behavior on mobile

### DIFF
--- a/.changeset/full-chefs-sneeze.md
+++ b/.changeset/full-chefs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Fixes drawer behavior on mobile devices

--- a/packages/client/src/components/ui/Drawer.tsx
+++ b/packages/client/src/components/ui/Drawer.tsx
@@ -1,9 +1,11 @@
 import type { DynamicProps } from "@corvu/drawer";
 import DrawerPrimitive from "@corvu/drawer";
 import type { ComponentProps, ValidComponent } from "solid-js";
-import { mergeProps, Show, splitProps } from "solid-js";
+import { mergeProps, Show, splitProps, useContext } from "solid-js";
 
+import { ViewportContext } from "../../contexts/Viewport";
 import { cx } from "../../utils/cva";
+import { useIsMobile } from "../../utils/mobile-pane";
 
 export const DrawerPortal = DrawerPrimitive.Portal;
 
@@ -40,6 +42,13 @@ export const DrawerContent = <T extends ValidComponent = "div">(
 	props: DrawerContentProps<T>,
 ) => {
 	const context = DrawerPrimitive.useContext();
+	const viewportCtx = useContext(ViewportContext);
+	const isMobile = useIsMobile();
+	const isBottom = () => context.side() === "bottom";
+	const keyboardOffset = () =>
+		isMobile() && isBottom() ? (viewportCtx?.keyboardInset() ?? 0) : 0;
+	const maxHeightPx = () =>
+		isMobile() && isBottom() ? viewportCtx?.height() : undefined;
 
 	const merge = mergeProps<DrawerContentProps[]>(
 		{
@@ -47,7 +56,12 @@ export const DrawerContent = <T extends ValidComponent = "div">(
 		},
 		props as DrawerContentProps,
 	);
-	const [, rest] = splitProps(merge, ["class", "children", "withHandle"]);
+	const [local, rest] = splitProps(merge, [
+		"class",
+		"children",
+		"withHandle",
+		"style",
+	]);
 
 	return (
 		<>
@@ -81,6 +95,13 @@ export const DrawerContent = <T extends ValidComponent = "div">(
 					props.class,
 				)}
 				{...rest}
+				style={{
+					...(typeof local.style === "object" ? local.style : {}),
+					...(keyboardOffset() > 0 ? { bottom: `${keyboardOffset()}px` } : {}),
+					...(maxHeightPx() !== undefined
+						? { "max-height": `${maxHeightPx()}px` }
+						: {}),
+				}}
 			>
 				<Show when={props.withHandle}>
 					<div

--- a/packages/client/src/components/ui/MenuDrawer.tsx
+++ b/packages/client/src/components/ui/MenuDrawer.tsx
@@ -6,9 +6,12 @@ import {
 	onCleanup,
 	Show,
 	splitProps,
+	useContext,
 } from "solid-js";
 import { Portal } from "solid-js/web";
+import { ViewportContext } from "../../contexts/Viewport";
 import { cx } from "../../utils/cva";
+import { useIsMobile } from "../../utils/mobile-pane";
 
 export const DRAWER_TRANSITION_MS = 300;
 
@@ -34,6 +37,12 @@ export const BottomSheet = (props: BottomSheetProps) => {
 	const [shown, setShown] = createSignal(false);
 	const [dragOffset, setDragOffset] = createSignal(0);
 	const [dragging, setDragging] = createSignal(false);
+
+	const viewportCtx = useContext(ViewportContext);
+	const isMobile = useIsMobile();
+	const keyboardOffset = () =>
+		isMobile() ? (viewportCtx?.keyboardInset() ?? 0) : 0;
+	const maxHeightPx = () => (isMobile() ? viewportCtx?.height() : undefined);
 
 	let closeTimer: number | undefined;
 	let raf1 = 0;
@@ -126,7 +135,7 @@ export const BottomSheet = (props: BottomSheetProps) => {
 	return (
 		<Show when={mounted()}>
 			<Portal>
-				<div class="fixed inset-0 z-50">
+				<div class="fixed inset-0 z-50 pointer-events-auto">
 					<div
 						class="absolute inset-0 bg-black/50 transition-opacity duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
 						classList={{ "opacity-100": shown(), "opacity-0": !shown() }}
@@ -141,7 +150,15 @@ export const BottomSheet = (props: BottomSheetProps) => {
 								"transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]",
 							props.class,
 						)}
-						style={{ transform: sheetTransform() }}
+						style={{
+							transform: sheetTransform(),
+							...(keyboardOffset() > 0
+								? { bottom: `${keyboardOffset()}px` }
+								: {}),
+							...(maxHeightPx() !== undefined
+								? { "max-height": `${maxHeightPx()}px` }
+								: {}),
+						}}
 					>
 						<Show when={!props.hideHandle}>
 							<div

--- a/packages/client/src/utils/visual-viewport.ts
+++ b/packages/client/src/utils/visual-viewport.ts
@@ -3,6 +3,7 @@ import { type Accessor, createSignal, onCleanup } from "solid-js";
 export type ViewportMetrics = {
 	height: Accessor<number | undefined>;
 	offsetTop: Accessor<number>;
+	keyboardInset: Accessor<number>;
 };
 
 /**
@@ -28,7 +29,7 @@ export const createViewportMetrics = (): ViewportMetrics => {
 	}
 
 	const vv = typeof window !== "undefined" ? window.visualViewport : undefined;
-	if (!vv) return { height, offsetTop };
+	if (!vv) return { height, offsetTop, keyboardInset };
 
 	const update = () => {
 		setVvHeight(vv.height);
@@ -43,5 +44,5 @@ export const createViewportMetrics = (): ViewportMetrics => {
 		vv.removeEventListener("scroll", update);
 	});
 
-	return { height, offsetTop };
+	return { height, offsetTop, keyboardInset };
 };


### PR DESCRIPTION
### 🔗 Linked issue

#81 

### 🧭 Context

Currently, drawers behave weirdly on mobile devices and do not respect the keyboard.

### 📚 Description

This PR fixes that, plus some overlapping issues.