### PR TITLE
fix: Don't focus text editor on mobile

### DIFF
--- a/.changeset/silly-eels-jump.md
+++ b/.changeset/silly-eels-jump.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Stops the message composer from auto-focusing (and popping the on-screen keyboard) on mobile when opening or switching channels

--- a/packages/client/src/components/app/common/text-editor/TextEditor.tsx
+++ b/packages/client/src/components/app/common/text-editor/TextEditor.tsx
@@ -986,6 +986,7 @@ export const TextEditor: Component<{
 
 	createEffect(() => {
 		if (!editor() || editor()?.isFocused) return;
+		if (props.mainEditor && isMobile()) return;
 
 		editor()!.commands.focus("end", { scrollIntoView: true });
 	});
@@ -1026,7 +1027,7 @@ export const TextEditor: Component<{
 			else instance.commands.clearContent();
 			latest = instance.getJSON();
 			latestEmpty = instance.isEmpty;
-			if (instance.isFocused) instance.commands.focus("end");
+			if (instance.isFocused && !isMobile()) instance.commands.focus("end");
 		};
 
 		createEffect(() => {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #84

### 🧭 Context

Currently, the text input is always focused when entering a channel. This is a leftover from when the app was web and desktop only. On mobile devices, this causes the keyboard to pop up, which leads to bad accessibility.

### 📚 Description

This PR ensures the input is only focused on non-mobile devices.