### PR TITLE
fix: Broken atproto.at links on profile cards

### DIFF
--- a/.changeset/social-dingos-enter.md
+++ b/.changeset/social-dingos-enter.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Fixes broken atproto.at links on profile cards

--- a/packages/client/src/components/app/user/ProfilePopover.tsx
+++ b/packages/client/src/components/app/user/ProfilePopover.tsx
@@ -256,7 +256,7 @@ export const ProfilePopoverContents: Component<{
 								<Tooltip open={atProtoAtTooltipVisible()}>
 									<TooltipTrigger>
 										<a
-											href={`https://atproto.at/uri/at://${props.user.handle}`}
+											href={`https://atproto.at/uri/at://${props.user.handle.replaceAll("at://", "")}`}
 											target="_blank"
 											rel="noreferrer"
 											class="hover:text-[#1185fe] flex flex-row items-center gap-1.5 text-sm text-card-foreground font-normal hover:underline"


### PR DESCRIPTION
### 🔗 Linked issue

Closes #86

### 🧭 Context

The atproto.at links on some profiles are broken.

### 📚 Description
This PR ensures that any `at://` prefix for a handle is stripped when the link is constructed.