### PR TITLE
fix: Add missing toaster padding

### DIFF
--- a/.changeset/spicy-games-tap.md
+++ b/.changeset/spicy-games-tap.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Fixes missing padding for the toaster component

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -365,6 +365,14 @@ ol[data-somoto-toaster] > li {
 	ol[data-somoto-toaster] > li {
 		width: calc(100% - var(--mobile-offset, 16px) * 2) !important;
 	}
+
+	ol[data-somoto-toaster][data-y-position="top"] {
+		top: max(var(--offset), var(--safe-area-top)) !important;
+	}
+
+	ol[data-somoto-toaster][data-y-position="bottom"] {
+		bottom: max(var(--offset), var(--safe-area-bottom)) !important;
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #87 

### 🧭 Context

Currently, toasts on mobile intrude on the safe padding required for the app to not be shown behind the info bar at the top.

### 📚 Description

This PR adds safe top and bottom padding to the toaster.