### PR TITLE
fix: Open drawers while user is still pressing

### DIFF
--- a/.changeset/slow-seals-type.md
+++ b/.changeset/slow-seals-type.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Fixes mobile drawers only opening when the user released a press instead of when they pressed for long enough

--- a/packages/client/src/utils/create-long-press.ts
+++ b/packages/client/src/utils/create-long-press.ts
@@ -19,7 +19,7 @@ export const createLongPress = (el: HTMLElement, opts: LongPressOptions) => {
 	let startY = 0;
 	let pressing = false;
 	let moved = false;
-	let armed = false;
+	let lastEvent: PointerEvent | undefined;
 	let armTimer: number | undefined;
 	let suppressClickUntil = 0;
 
@@ -53,33 +53,31 @@ export const createLongPress = (el: HTMLElement, opts: LongPressOptions) => {
 		startY = e.clientY;
 		pressing = true;
 		moved = false;
-		armed = false;
+		lastEvent = e;
 		disarm();
 		armTimer = window.setTimeout(() => {
-			armed = true;
+			armTimer = undefined;
+			if (pressing && !moved && lastEvent) fire(lastEvent);
 		}, delay);
 	};
 
 	const onPointerMove = (e: PointerEvent) => {
 		if (!pressing || moved) return;
+		lastEvent = e;
 		if (Math.hypot(e.clientX - startX, e.clientY - startY) > moveCancel) {
 			moved = true;
 			disarm();
 		}
 	};
 
-	const onPointerUp = (e: PointerEvent) => {
-		if (!pressing) return;
+	const onPointerUp = () => {
 		pressing = false;
 		disarm();
-		if (armed && !moved) fire(e);
 	};
 
-	const onPointerCancel = (e: PointerEvent) => {
-		if (!pressing) return;
+	const onPointerCancel = () => {
 		pressing = false;
 		disarm();
-		if (armed && !moved) fire(e);
 	};
 
 	const onContextMenu = (e: Event) => {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #97

### 🧭 Context

Currently, long-pressing a message or other triggers for a drawer only shows the drawer after the press is released, which does not match the OS behavior.

### 📚 Description

This PR makes our implementation closer to the OS one.