### PR TITLE
fix: Mobile clipboard support

### DIFF
--- a/.changeset/khaki-steaks-allow.md
+++ b/.changeset/khaki-steaks-allow.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Adds clipboard support for iOS and Android

--- a/packages/client/src/components/app/common/text-editor/TextEditor.tsx
+++ b/packages/client/src/components/app/common/text-editor/TextEditor.tsx
@@ -596,6 +596,44 @@ const writeSelectionToClipboard = (
 	return true;
 };
 
+/**
+ * Pulls image files out of a `DataTransfer`. Works for both `ClipboardEvent`
+ * (paste gesture) and `InputEvent` (Android IME rich-content insertion, e.g.
+ * tapping the Gboard clipboard image chip)
+ */
+const extractImageFiles = (data: DataTransfer | null): Array<File> => {
+	if (!data) return [];
+
+	const files: Array<File> = [];
+	const seen = new Set<File>();
+
+	const add = (file: File | null) => {
+		if (!file || seen.has(file) || !file.type.startsWith("image/")) return;
+		seen.add(file);
+		const ext = file.type.split("/")[1] || "png";
+		const named =
+			file.name.trim().length > 0
+				? file
+				: new File(
+						[file],
+						`pasted-image-${Date.now()}-${files.length}.${ext}`,
+						{
+							type: file.type,
+						},
+					);
+		files.push(named);
+	};
+
+	for (const item of data.items) {
+		if (item.kind === "file" && item.type.startsWith("image/")) {
+			add(item.getAsFile());
+		}
+	}
+	for (const file of data.files) add(file);
+
+	return files;
+};
+
 export const TextEditor: Component<{
 	placeholder: string;
 	text?: ReturnType<Editor["getJSON"]>;
@@ -610,6 +648,7 @@ export const TextEditor: Component<{
 	onEmptyChange?: (empty: boolean) => void;
 	registerSubmit?: (submit: () => void) => void;
 	onProgress?: (percentage: number) => void;
+	onImagePaste?: (files: Array<File>) => void;
 }> = (props) => {
 	let ref!: HTMLDivElement;
 
@@ -847,10 +886,33 @@ export const TextEditor: Component<{
 					view.dispatch(view.state.tr.deleteSelection());
 					return true;
 				},
+				beforeinput: (_view, event) => {
+					if (!props.onImagePaste) return false;
+					const inputEvent = event as InputEvent;
+					if (
+						inputEvent.inputType !== "insertFromPaste" &&
+						inputEvent.inputType !== "insertReplacementText"
+					) {
+						return false;
+					}
+					const images = extractImageFiles(inputEvent.dataTransfer);
+					if (images.length === 0) return false;
+					props.onImagePaste(images);
+					event.preventDefault();
+					return true;
+				},
 			},
 			handlePaste: (_view, event) => {
 				const instance = editor();
 				if (!instance || instance.isDestroyed) return false;
+
+				if (props.onImagePaste) {
+					const images = extractImageFiles(event.clipboardData);
+					if (images.length > 0) {
+						props.onImagePaste(images);
+						return true;
+					}
+				}
 
 				const payload = readClipboardFacets(
 					event.clipboardData?.getData("text/html"),

--- a/packages/client/src/components/app/community/MessageInput.tsx
+++ b/packages/client/src/components/app/community/MessageInput.tsx
@@ -337,25 +337,14 @@ export const MessageInput: Component<{
 						<FileFieldTrigger class="w-10 h-10 min-w-10 bg-muted text-muted-foreground hover:text-primary-foreground flex items-center justify-center rounded-lg cursor-pointer">
 							<PlusIcon />
 						</FileFieldTrigger>
-						<div
-							ref={inputEl}
-							class="flex-1 min-w-0"
-							onPaste={(e) => {
-								if ((e.clipboardData?.files.length || 0) > 0) {
-									e.preventDefault();
-
-									for (const file of e.clipboardData!.files) {
-										fileField.processFiles([file]);
-									}
-								}
-							}}
-						>
+						<div ref={inputEl} class="flex-1 min-w-0">
 							<div class="w-full">
 								<TextEditor
 									mainEditor
 									placeholder={`Message ${props.channelName}`}
 									sendMessage={handleSubmit}
 									onChange={handleTypingChange}
+									onImagePaste={(files) => fileField.processFiles(files)}
 									onEscape={() =>
 										isEditingOnMobile()
 											? channel.cancelMessageEdit()


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Currently, trying to paste an image on mobile via the keyboard does not work. Google's Keyboard even says the input does not support images, which is wrong.

### 📚 Description

Improves the paste handler to also listen for mobile-specific events.