### PR TITLE
fix: Dismiss notifs upon channel read

### DIFF
--- a/.changeset/many-masks-travel.md
+++ b/.changeset/many-masks-travel.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/client": patch
+---
+
+Automatically dismisses notifications if a channel is opened and the notification is still there.

--- a/packages/client/src/contexts/Notifications.tsx
+++ b/packages/client/src/contexts/Notifications.tsx
@@ -11,7 +11,10 @@ import {
 } from "solid-js";
 import { toast } from "somoto";
 import { writeReadCursor } from "../atproto/read-cursor";
-import { isStaleNotificationEvent } from "../notifications";
+import {
+	cancelChannelTrayNotification,
+	isStaleNotificationEvent,
+} from "../notifications";
 import { useMutes } from "./Mutes";
 import { useSocketContext } from "./Socket";
 import { useSounds } from "./Sounds";
@@ -108,6 +111,7 @@ export const NotificationsContextProvider: ParentComponent = (props) => {
 	>({});
 
 	const accountedMessages = new Set<string>();
+	const locallyReadChannels = new Set<string>();
 
 	const clearPendingFocus = () => setPendingFocus(undefined);
 
@@ -163,7 +167,8 @@ export const NotificationsContextProvider: ParentComponent = (props) => {
 			return { ...prev, [key]: true };
 		});
 
-	const markChannelRead = (channelUri: string) =>
+	const markChannelRead = (channelUri: string) => {
+		locallyReadChannels.add(channelKey(channelUri));
 		setUnreadChannels((prev) => {
 			const key = channelKey(channelUri);
 			if (!prev[key]) return prev;
@@ -171,6 +176,7 @@ export const NotificationsContextProvider: ParentComponent = (props) => {
 			delete next[key];
 			return next;
 		});
+	};
 
 	const markMessageSeen = async (
 		messageUri: string,
@@ -178,6 +184,7 @@ export const NotificationsContextProvider: ParentComponent = (props) => {
 	): Promise<void> => {
 		if (accountedMessages.has(messageUri)) return;
 		accountedMessages.add(messageUri);
+		void cancelChannelTrayNotification(channelUri);
 
 		adjustPings(channelUri, -1);
 		try {
@@ -287,6 +294,10 @@ export const NotificationsContextProvider: ParentComponent = (props) => {
 			for (const ch of res.channels) {
 				const key = channelKey(ch.channelUri);
 				if (mutes.isChannelMuted(ch.channelUri)) {
+					delete next[key];
+					continue;
+				}
+				if (locallyReadChannels.has(key)) {
 					delete next[key];
 					continue;
 				}

--- a/packages/client/src/layouts/ChannelLayout.tsx
+++ b/packages/client/src/layouts/ChannelLayout.tsx
@@ -45,6 +45,7 @@ import { ScrollAnchorProvider } from "../contexts/ScrollAnchor";
 import { useUserContext } from "../contexts/User";
 import { useUserPreferences } from "../contexts/UserPreferences";
 import { useViewport } from "../contexts/Viewport";
+import { cancelChannelTrayNotification } from "../notifications";
 import { getChannelParam } from "../utils/get-param";
 import { createMobilePane } from "../utils/mobile-pane";
 
@@ -243,6 +244,7 @@ const ChannelLayout: ParentComponent = (props) => {
 		if (wasAtBottom) {
 			channel.advanceReadCursor();
 			notifications.markChannelRead(channel.channelUri());
+			void cancelChannelTrayNotification(channel.channelUri());
 		}
 	};
 
@@ -466,15 +468,28 @@ const ChannelLayout: ParentComponent = (props) => {
 						)
 					: null;
 
+			const markReadNow = () => {
+				channel.advanceReadCursor();
+				notifications.markChannelRead(channel.channelUri());
+				void cancelChannelTrayNotification(channel.channelUri());
+			};
+
 			if (node) {
 				node.scrollIntoView({ block: "start" });
+				const distFromBottom = scrollContainer
+					? scrollContainer.scrollHeight -
+						scrollContainer.scrollTop -
+						scrollContainer.clientHeight
+					: Number.POSITIVE_INFINITY;
+				if (distFromBottom < 80) {
+					wasAtBottom = true;
+					markReadNow();
+				}
 			} else {
 				wasAtBottom = true;
 				pinToBottomStable();
+				markReadNow();
 			}
-
-			channel.advanceReadCursor();
-			notifications.markChannelRead(channel.channelUri());
 		});
 	});
 

--- a/packages/client/src/notifications/index.ts
+++ b/packages/client/src/notifications/index.ts
@@ -59,6 +59,7 @@ export {
 	isTauriRuntime,
 	isWebRuntime,
 } from "./environment";
+export { cancelChannelTrayNotification } from "./tauri";
 export type {
 	NotificationBackend,
 	NotificationPayload,

--- a/packages/client/src/notifications/tauri.ts
+++ b/packages/client/src/notifications/tauri.ts
@@ -1,4 +1,4 @@
-import { isTauriRuntime } from "./environment";
+import { isAndroidTauriRuntime, isTauriRuntime } from "./environment";
 import type {
 	NotificationBackend,
 	NotificationPayload,
@@ -13,6 +13,24 @@ import type {
  * never runs.
  */
 const loadPlugin = () => import("@tauri-apps/plugin-notification");
+
+const javaStringHashCode = (value: string): number => {
+	let hash = 0;
+	for (let i = 0; i < value.length; i++) {
+		hash = (Math.imul(31, hash) + value.charCodeAt(i)) | 0;
+	}
+	return hash;
+};
+
+export const cancelChannelTrayNotification = async (
+	channelUri: string,
+): Promise<void> => {
+	if (!(await isAndroidTauriRuntime())) return;
+	try {
+		const { removeActive } = await loadPlugin();
+		await removeActive([{ id: javaStringHashCode(channelUri) }]);
+	} catch {}
+};
 
 export const tauriBackend: NotificationBackend = {
 	name: "tauri",


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Currently, navigating to a channel manually without tapping on a notification leaves that notification in place.

### 📚 Description

This PR introduces a fix so notifications are cleared when the relevant message is read.
