### PR TITLE
feat: Improve loading speed and storage for IndexedDB messages

### DIFF
--- a/.changeset/olive-pianos-shake.md
+++ b/.changeset/olive-pianos-shake.md
@@ -2,7 +2,7 @@
 "@colibri-social/client": patch
 ---
 
-Fixes channels showing stale messages when you open the app. Busy channels never saved their history at all, so reopening one could show a conversation from days ago until the network caught up, and a message someone deleted while you were reading elsewhere would come back from the dead. Saved history is now kept current in the background for every channel, not just the one you have open, and anything older than a day is no longer shown as if it were current. Messages also arrive much sooner after a reload: the first page is now requested as soon as you're signed in rather than after your profile and community have both finished loading, and anything posted while the app was still starting up no longer stays hidden until you click back into the window. A message you sent while a channel was still loading is no longer dropped from the list.
+Fixes channels showing stale messages when you open the app. Busy channels never saved their history at all, so reopening one could show a conversation from days ago until the network caught up, and a message someone deleted while you were reading elsewhere would come back from the dead. Saved history is now kept current in the background for every channel, not just the one you have open, and anything older than a day is no longer shown as if it were current.
 
 <!-- whatsnew
 title: Faster, fresher messages

--- a/.changeset/olive-pianos-shake.md
+++ b/.changeset/olive-pianos-shake.md
@@ -1,0 +1,12 @@
+---
+"@colibri-social/client": patch
+---
+
+Fixes channels showing stale messages when you open the app. Busy channels never saved their history at all, so reopening one could show a conversation from days ago until the network caught up, and a message someone deleted while you were reading elsewhere would come back from the dead. Saved history is now kept current in the background for every channel, not just the one you have open, and anything older than a day is no longer shown as if it were current. Messages also arrive much sooner after a reload: the first page is now requested as soon as you're signed in rather than after your profile and community have both finished loading, and anything posted while the app was still starting up no longer stays hidden until you click back into the window. A message you sent while a channel was still loading is no longer dropped from the list.
+
+<!-- whatsnew
+title: Faster, fresher messages
+icon: rewind-fill
+body: Channels now load up-to-date messages much sooner, and no longer show conversations that have fallen behind.
+kind: fix
+-->

--- a/.changeset/quick-pears-repeat.md
+++ b/.changeset/quick-pears-repeat.md
@@ -1,0 +1,5 @@
+---
+"@colibri-social/wrapper": patch
+---
+
+Makes the direct-distribution macOS build reliable.

--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -19,6 +19,9 @@ COPY apps/website/package.json ./apps/website/
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --store-dir=/pnpm/store
 
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm add @colibri-social/client --yes
+
 # Declare build args
 ARG APPVIEW_DOMAIN
 ARG SAME_TLD_DID

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"whats-new:check": "node --experimental-strip-types scripts/check-whats-new.ts",
 		"whats-new:generate": "node --experimental-strip-types scripts/collect-release-notes.ts generate",
 		"whats-new:preview": "node --experimental-strip-types scripts/collect-release-notes.ts preview",
-		"typecheck:scripts": "tsc -p tsconfig.scripts.json",
+		"typecheck:scripts": "tsc --build tsconfig.scripts.json",
 		"lint": "biome check .",
 		"lint:fix": "biome check . --write",
 		"format": "biome format . --write",

--- a/packages/client/src/atproto/auth.ts
+++ b/packages/client/src/atproto/auth.ts
@@ -480,7 +480,7 @@ export type Client =
 			loggedIn: true;
 			agent: Agent;
 			client: BrowserOAuthClient;
-			pdsHost: string;
+			pdsHost: string | undefined;
 			grantedScopes: string | undefined;
 	  }
 	| { loggedIn: false; client: BrowserOAuthClient }
@@ -491,7 +491,7 @@ type ClientGetter = () => Promise<Client>;
 const getClient: ClientGetter = () => {
 	return new Promise((res) => {
 		init().then(() => {
-			if (oAuthClient && agent && pdsHost) {
+			if (oAuthClient && agent) {
 				res({
 					loggedIn: true,
 					client: oAuthClient,
@@ -572,24 +572,50 @@ const init = async () => {
 
 	if (!agent) return;
 
+	pdsHost = readCachedPdsHost(agent.did!);
+	void resolvePdsHost(agent.did!);
+};
+
+const pdsHostKey = (did: string) => `colibri:pds:${did}`;
+
+const readCachedPdsHost = (did: string): string | undefined => {
+	try {
+		return localStorage.getItem(pdsHostKey(did)) ?? undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+const resolvePdsHost = async (did: string): Promise<void> => {
 	try {
 		const didDoc = (await (
 			await fetch(
-				`${getAppViewHost("http")}/xrpc/com.atproto.identity.resolveDid?did=${agent.did!}`,
+				`${getAppViewHost("http")}/xrpc/com.atproto.identity.resolveDid?did=${did}`,
 			)
 		).json()) as DidDocument;
 
 		if (!didDoc.service) {
-			throw new Error(
-				`DID document for ${agent.did!} did not include any services.`,
-			);
+			throw new ColibriError({
+				code: "MalformedResponse",
+				method: "com.atproto.identity.resolveDid",
+				context: { did },
+			});
 		}
 
-		pdsHost = didDoc.service
+		const resolved = didDoc.service
 			.find((x) => x.id === "#atproto_pds")
 			?.serviceEndpoint.toString();
+
+		if (!resolved) return;
+		pdsHost = resolved;
+		try {
+			localStorage.setItem(pdsHostKey(did), resolved);
+		} catch {}
 	} catch (e) {
-		log.error("resolving the PDS host failed", { error: e });
+		const failure = classifyThrown(e, {
+			method: "com.atproto.identity.resolveDid",
+		});
+		log.warn("resolving the PDS host failed", { code: failure.code });
 	}
 };
 

--- a/packages/client/src/atproto/auth.ts
+++ b/packages/client/src/atproto/auth.ts
@@ -4,6 +4,7 @@ import {
 	type DidDocument,
 } from "@atproto/oauth-client-browser";
 import * as Sentry from "@sentry/solid";
+import { type Accessor, createSignal } from "solid-js";
 import { toast } from "somoto";
 import { classifyThrown } from "../errors/classify";
 import { ColibriError, isColibriError } from "../errors/error";
@@ -19,6 +20,7 @@ import {
 } from "../utils/appview";
 import { deviceContext, getConnection } from "../utils/device-context";
 import { createLogger } from "../utils/logger";
+import { markBoot } from "../utils/perf";
 import { isAllowedDid } from "./allowlist";
 import { buildScopes, getMissingScopeSets } from "./scopes";
 import {
@@ -409,8 +411,12 @@ export const asSignInError = (err: unknown): ColibriError => {
 let oAuthClient: undefined | BrowserOAuthClient;
 let agent: undefined | Agent;
 let pdsHost: undefined | string;
-let grantedScopes: undefined | string;
+const [grantedScopes, setGrantedScopes] = createSignal<string | undefined>(
+	undefined,
+);
 let usingFallbackStorage = false;
+
+export { grantedScopes };
 
 const FALLBACK_FLAG_KEY = "colibri:oauth-storage-fallback";
 
@@ -472,7 +478,7 @@ const clearDisallowedSession = async (sub: string) => {
 	localStorage.removeItem("sub");
 	agent = undefined;
 	pdsHost = undefined;
-	grantedScopes = undefined;
+	setGrantedScopes(undefined);
 };
 
 export type Client =
@@ -481,7 +487,7 @@ export type Client =
 			agent: Agent;
 			client: BrowserOAuthClient;
 			pdsHost: string | undefined;
-			grantedScopes: string | undefined;
+			grantedScopes: Accessor<string | undefined>;
 	  }
 	| { loggedIn: false; client: BrowserOAuthClient }
 	| undefined;
@@ -511,11 +517,25 @@ const getClient: ClientGetter = () => {
 	});
 };
 
+type RestoredSession = Awaited<ReturnType<BrowserOAuthClient["restore"]>>;
+
+const revalidateGrantedScopes = async (
+	session: RestoredSession,
+): Promise<void> => {
+	try {
+		setGrantedScopes((await session.getTokenInfo(true)).scope);
+		markBoot("auth:scopesRevalidated");
+	} catch (e) {
+		const failure = classifyThrown(e, { method: "oauth.getTokenInfo" });
+		log.warn("forced token refresh failed", { code: failure.code });
+	}
+};
+
 const resetSession = () => {
 	localStorage.removeItem("sub");
 	agent = undefined;
 	pdsHost = undefined;
-	grantedScopes = undefined;
+	setGrantedScopes(undefined);
 };
 
 const init = async () => {
@@ -688,20 +708,17 @@ const restoreExistingSession = async () => {
 		agent = new Agent(session);
 
 		try {
-			grantedScopes = (await session.getTokenInfo(false)).scope;
+			setGrantedScopes((await session.getTokenInfo(false)).scope);
 		} catch {}
 
+		const cached = grantedScopes();
 		if (
 			state == null &&
 			navigator.onLine &&
-			grantedScopes !== undefined &&
-			getMissingScopeSets(grantedScopes).length === 0
+			cached !== undefined &&
+			getMissingScopeSets(cached).length === 0
 		) {
-			try {
-				grantedScopes = (await session.getTokenInfo(true)).scope;
-			} catch (e) {
-				log.warn("forced token refresh failed", { error: e });
-			}
+			void revalidateGrantedScopes(session);
 		}
 	}
 };

--- a/packages/client/src/atproto/cache/messages-snapshot.test.ts
+++ b/packages/client/src/atproto/cache/messages-snapshot.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../xrpc/social/colibri/channel/listMessages";
+import {
+	buildMessagesSnapshot,
+	cursorFor,
+	isSnapshotPaintable,
+	isSnapshotStale,
+	MESSAGES_HARD_TTL_MS,
+	MESSAGES_STALE_HINT_MS,
+	restoreMessagesSnapshot,
+	rkeyOf,
+	shouldWriteSnapshot,
+	snapshotAgeMs,
+} from "./messages-snapshot";
+import type { MessagesSnapshot } from "./schema";
+
+const DID = "did:plc:abc123";
+const CHANNEL = `at://${DID}/social.colibri.channel/general`;
+const COMMUNITY = `at://${DID}/social.colibri.community/self`;
+
+const author = {
+	did: DID,
+	handle: "someone.example",
+	data: { displayName: "Someone" },
+} as unknown as Message["author"];
+
+const message = (rkey: string): Message => ({
+	uri: `at://${DID}/social.colibri.message/${rkey}`,
+	text: "hello",
+	facets: [],
+	channel: CHANNEL,
+	community: COMMUNITY,
+	author,
+	attachments: [],
+	reactions: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	edited: false,
+});
+
+const run = (count: number, from = 0): Message[] =>
+	Array.from({ length: count }, (_, i) => message(`m${from + i}`));
+
+const options = (
+	overrides?: Partial<Parameters<typeof buildMessagesSnapshot>[1]>,
+) => ({
+	readCursor: undefined,
+	hasMore: true,
+	limit: 50,
+	now: 1234,
+	...overrides,
+});
+
+describe("rkeyOf", () => {
+	it("returns the last path segment of an AT URI", () => {
+		expect(rkeyOf(`at://${DID}/social.colibri.message/abc`)).toBe("abc");
+	});
+
+	it("returns an empty string for an empty input", () => {
+		expect(rkeyOf("")).toBe("");
+	});
+});
+
+describe("cursorFor", () => {
+	it("derives the cursor from the oldest message", () => {
+		expect(cursorFor(run(3))).toBe("m0");
+	});
+
+	it("falls back when there are no messages", () => {
+		expect(cursorFor([], "kept")).toBe("kept");
+		expect(cursorFor([])).toBeUndefined();
+	});
+});
+
+describe("buildMessagesSnapshot", () => {
+	it("keeps the newest page and stamps the cursor from it", () => {
+		const snap = buildMessagesSnapshot(run(60), options());
+
+		expect(snap.messages).toHaveLength(50);
+		expect(snap.messages[0]?.uri).toContain("m10");
+		expect(snap.cursor).toBe("m10");
+	});
+
+	it("forces hasMore when the snapshot was truncated", () => {
+		const snap = buildMessagesSnapshot(run(60), options({ hasMore: false }));
+
+		expect(snap.hasMore).toBe(true);
+	});
+
+	it("carries hasMore through when nothing was dropped", () => {
+		const snap = buildMessagesSnapshot(run(10), options({ hasMore: false }));
+
+		expect(snap.messages).toHaveLength(10);
+		expect(snap.hasMore).toBe(false);
+		expect(snap.cursor).toBe("m0");
+	});
+
+	it("records the read cursor and timestamp verbatim", () => {
+		const snap = buildMessagesSnapshot(
+			run(3),
+			options({ readCursor: "cursor-uri", now: 999 }),
+		);
+
+		expect(snap.readCursor).toBe("cursor-uri");
+		expect(snap.ts).toBe(999);
+	});
+
+	it("produces an empty snapshot without a cursor", () => {
+		const snap = buildMessagesSnapshot([], options());
+
+		expect(snap.messages).toEqual([]);
+		expect(snap.cursor).toBeUndefined();
+	});
+});
+
+describe("restoreMessagesSnapshot", () => {
+	it("prefers the persisted cursor and hasMore", () => {
+		const snap: MessagesSnapshot = {
+			messages: run(3),
+			cursor: "persisted",
+			hasMore: false,
+			ts: 1,
+		};
+
+		expect(restoreMessagesSnapshot(snap)).toEqual({
+			cursor: "persisted",
+			hasMore: false,
+		});
+	});
+
+	it("derives the cursor from a snapshot written before the fields existed", () => {
+		const snap: MessagesSnapshot = { messages: run(3), ts: 1 };
+
+		expect(restoreMessagesSnapshot(snap)).toEqual({
+			cursor: "m0",
+			hasMore: undefined,
+		});
+	});
+
+	it("round-trips a built snapshot", () => {
+		const built = buildMessagesSnapshot(run(10), options({ hasMore: false }));
+
+		expect(restoreMessagesSnapshot(built)).toEqual({
+			cursor: "m0",
+			hasMore: false,
+		});
+	});
+});
+
+describe("snapshotAgeMs", () => {
+	it("measures the snapshot against the supplied clock", () => {
+		expect(snapshotAgeMs({ messages: [], ts: 1000 }, 4000)).toBe(3000);
+	});
+});
+
+describe("isSnapshotPaintable", () => {
+	it("paints a fresh snapshot", () => {
+		expect(isSnapshotPaintable(0)).toBe(true);
+		expect(isSnapshotPaintable(60_000)).toBe(true);
+	});
+
+	it("paints a snapshot exactly at the hard TTL", () => {
+		expect(isSnapshotPaintable(MESSAGES_HARD_TTL_MS)).toBe(true);
+	});
+
+	it("refuses a snapshot past the hard TTL", () => {
+		expect(isSnapshotPaintable(MESSAGES_HARD_TTL_MS + 1)).toBe(false);
+	});
+
+	it("refuses a snapshot stamped in the future", () => {
+		expect(isSnapshotPaintable(-1)).toBe(false);
+	});
+});
+
+describe("isSnapshotStale", () => {
+	it("stays quiet for a snapshot within the hint window", () => {
+		expect(isSnapshotStale(0)).toBe(false);
+		expect(isSnapshotStale(MESSAGES_STALE_HINT_MS)).toBe(false);
+	});
+
+	it("flags a snapshot past the hint window", () => {
+		expect(isSnapshotStale(MESSAGES_STALE_HINT_MS + 1)).toBe(true);
+	});
+
+	it("stays quiet when there is no snapshot", () => {
+		expect(isSnapshotStale(undefined)).toBe(false);
+	});
+});
+
+describe("shouldWriteSnapshot", () => {
+	const gate = {
+		cacheEnabled: true,
+		channelUri: CHANNEL,
+		hydratedFromNetwork: true,
+		confirmedCount: 3,
+	};
+
+	it("allows a write once the network has hydrated the channel", () => {
+		expect(shouldWriteSnapshot(gate)).toBe(true);
+	});
+
+	it("blocks a write that would only persist a cache paint", () => {
+		expect(shouldWriteSnapshot({ ...gate, hydratedFromNetwork: false })).toBe(
+			false,
+		);
+	});
+
+	it("blocks a write when the cache is disabled", () => {
+		expect(shouldWriteSnapshot({ ...gate, cacheEnabled: false })).toBe(false);
+	});
+
+	it("blocks a write without a channel", () => {
+		expect(shouldWriteSnapshot({ ...gate, channelUri: "" })).toBe(false);
+	});
+
+	it("blocks a write with no confirmed messages", () => {
+		expect(shouldWriteSnapshot({ ...gate, confirmedCount: 0 })).toBe(false);
+	});
+});

--- a/packages/client/src/atproto/cache/messages-snapshot.ts
+++ b/packages/client/src/atproto/cache/messages-snapshot.ts
@@ -1,0 +1,64 @@
+import type { Message } from "../xrpc/social/colibri/channel/listMessages";
+import type { MessagesSnapshot } from "./schema";
+
+export const rkeyOf = (uri: string): string => uri.split("/").pop() ?? "";
+
+export const cursorFor = (
+	messages: Message[],
+	fallback?: string,
+): string | undefined => {
+	const oldest = messages[0];
+	return oldest ? rkeyOf(oldest.uri) : fallback;
+};
+
+export const buildMessagesSnapshot = (
+	confirmed: Message[],
+	options: {
+		readCursor: string | undefined;
+		hasMore: boolean;
+		limit: number;
+		now: number;
+	},
+): MessagesSnapshot => {
+	const kept = confirmed.slice(-options.limit);
+	return {
+		messages: kept,
+		readCursor: options.readCursor,
+		cursor: cursorFor(kept),
+		hasMore: kept.length < confirmed.length ? true : options.hasMore,
+		ts: options.now,
+	};
+};
+
+export const MESSAGES_HARD_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const MESSAGES_STALE_HINT_MS = 60_000;
+
+export const snapshotAgeMs = (
+	snapshot: MessagesSnapshot,
+	now: number,
+): number => now - snapshot.ts;
+
+export const isSnapshotPaintable = (ageMs: number): boolean =>
+	ageMs >= 0 && ageMs <= MESSAGES_HARD_TTL_MS;
+
+export const isSnapshotStale = (ageMs: number | undefined): boolean =>
+	ageMs !== undefined && ageMs > MESSAGES_STALE_HINT_MS;
+
+export const shouldWriteSnapshot = (input: {
+	cacheEnabled: boolean;
+	channelUri: string;
+	hydratedFromNetwork: boolean;
+	confirmedCount: number;
+}): boolean =>
+	input.cacheEnabled &&
+	input.channelUri.length > 0 &&
+	input.hydratedFromNetwork &&
+	input.confirmedCount > 0;
+
+export const restoreMessagesSnapshot = (
+	snapshot: MessagesSnapshot,
+): { cursor: string | undefined; hasMore: boolean | undefined } => ({
+	cursor: snapshot.cursor ?? cursorFor(snapshot.messages),
+	hasMore: snapshot.hasMore,
+});

--- a/packages/client/src/atproto/cache/messages-writer.test.ts
+++ b/packages/client/src/atproto/cache/messages-writer.test.ts
@@ -1,0 +1,151 @@
+import type { Colibri_MessageEvent } from "@colibri-social/lib";
+import { describe, expect, it } from "vitest";
+import type { Message } from "../xrpc/social/colibri/channel/listMessages";
+import {
+	applyMessageEvent,
+	isOpenChannel,
+	registerOpenChannel,
+} from "./messages-writer";
+import type { MessagesSnapshot } from "./schema";
+
+const DID = "did:plc:abc123";
+const CHANNEL = `at://${DID}/social.colibri.channel/general`;
+const COMMUNITY = `at://${DID}/social.colibri.community/self`;
+
+const author = {
+	did: DID,
+	handle: "someone.example",
+	data: { displayName: "Someone" },
+} as unknown as Message["author"];
+
+const message = (rkey: string, text = "hello"): Message => ({
+	uri: `at://${DID}/social.colibri.message/${rkey}`,
+	text,
+	facets: [],
+	channel: CHANNEL,
+	community: COMMUNITY,
+	author,
+	attachments: [],
+	reactions: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	edited: false,
+});
+
+const snapshot = (messages: Message[]): MessagesSnapshot => ({
+	messages,
+	ts: 1,
+});
+
+type Event = NonNullable<Colibri_MessageEvent["data"]>;
+
+const upsert = (rkey: string, text = "hello"): Event =>
+	({
+		event: "upsert",
+		uri: `at://${DID}/social.colibri.message/${rkey}`,
+		channel: CHANNEL,
+		text,
+		facets: [],
+		createdAt: "2026-01-01T00:00:00.000Z",
+		edited: false,
+		attachments: [],
+		author,
+	}) as unknown as Event;
+
+const remove = (rkey: string): Event =>
+	({
+		event: "delete",
+		uri: `at://${DID}/social.colibri.message/${rkey}`,
+		channel: CHANNEL,
+	}) as unknown as Event;
+
+describe("applyMessageEvent", () => {
+	it("appends a new message", () => {
+		const next = applyMessageEvent(snapshot([message("a")]), upsert("b"), 50);
+		expect(next?.messages.map((m) => m.text)).toEqual(["hello", "hello"]);
+		expect(next?.messages[1]?.uri).toContain("/b");
+	});
+
+	it("carries `community` over from an existing row", () => {
+		const next = applyMessageEvent(snapshot([message("a")]), upsert("b"), 50);
+		expect(next?.messages[1]?.community).toBe(COMMUNITY);
+	});
+
+	it("skips an event when the snapshot has no row to source `community` from", () => {
+		expect(applyMessageEvent(snapshot([]), upsert("b"), 50)).toBeUndefined();
+	});
+
+	it("edits in place rather than appending a duplicate", () => {
+		const next = applyMessageEvent(
+			snapshot([message("a"), message("b")]),
+			upsert("b", "edited"),
+			50,
+		);
+		expect(next?.messages).toHaveLength(2);
+		expect(next?.messages[1]?.text).toBe("edited");
+	});
+
+	it("keeps reactions on an edit, since the event carries none", () => {
+		const withReaction = message("b");
+		withReaction.reactions = [{ emoji: "👍", count: 1, reactorDIDs: [DID] }];
+		const next = applyMessageEvent(
+			snapshot([message("a"), withReaction]),
+			upsert("b", "edited"),
+			50,
+		);
+		expect(next?.messages[1]?.reactions).toHaveLength(1);
+	});
+
+	it("removes a deleted message", () => {
+		const next = applyMessageEvent(
+			snapshot([message("a"), message("b")]),
+			remove("b"),
+			50,
+		);
+		expect(next?.messages.map((m) => m.uri)).toEqual([
+			`at://${DID}/social.colibri.message/a`,
+		]);
+	});
+
+	it("reports no change when the deleted message is not in the snapshot", () => {
+		expect(
+			applyMessageEvent(snapshot([message("a")]), remove("zzz"), 50),
+		).toBeUndefined();
+	});
+
+	it("trims to the page size, keeping the newest rows", () => {
+		const next = applyMessageEvent(
+			snapshot([message("a"), message("b"), message("c")]),
+			upsert("d"),
+			3,
+		);
+		expect(next?.messages.map((m) => m.uri.split("/").pop())).toEqual([
+			"b",
+			"c",
+			"d",
+		]);
+	});
+
+	it("refreshes `ts` so an updated snapshot stays ahead in the LRU", () => {
+		const next = applyMessageEvent(snapshot([message("a")]), upsert("b"), 50);
+		expect(next?.ts).toBeGreaterThan(1);
+	});
+});
+
+describe("registerOpenChannel", () => {
+	it("reports the claimed channel as owned", () => {
+		registerOpenChannel(CHANNEL);
+		expect(isOpenChannel(CHANNEL)).toBe(true);
+		expect(isOpenChannel(`${CHANNEL}-other`)).toBe(false);
+	});
+
+	it("releases ownership", () => {
+		registerOpenChannel(CHANNEL);
+		registerOpenChannel(undefined);
+		expect(isOpenChannel(CHANNEL)).toBe(false);
+	});
+
+	it("treats an empty URI as no claim", () => {
+		registerOpenChannel("");
+		expect(isOpenChannel("")).toBe(false);
+	});
+});

--- a/packages/client/src/atproto/cache/messages-writer.ts
+++ b/packages/client/src/atproto/cache/messages-writer.ts
@@ -1,0 +1,48 @@
+import type { Colibri_MessageEvent } from "@colibri-social/lib";
+import type { Message } from "../xrpc/social/colibri/channel/listMessages";
+import type { MessagesSnapshot } from "./schema";
+
+let openChannel: string | undefined;
+
+export const registerOpenChannel = (uri: string | undefined): void => {
+	openChannel = uri || undefined;
+};
+
+export const isOpenChannel = (uri: string): boolean => openChannel === uri;
+
+export const applyMessageEvent = (
+	snapshot: MessagesSnapshot,
+	event: NonNullable<Colibri_MessageEvent["data"]>,
+	limit: number,
+): MessagesSnapshot | undefined => {
+	if (event.event === "delete") {
+		const remaining = snapshot.messages.filter((m) => m.uri !== event.uri);
+		if (remaining.length === snapshot.messages.length) return undefined;
+		return { ...snapshot, messages: remaining, ts: Date.now() };
+	}
+
+	const community = snapshot.messages[0]?.community;
+	if (!community) return undefined;
+
+	const existing = snapshot.messages.find((m) => m.uri === event.uri);
+
+	const message: Message = {
+		uri: event.uri,
+		text: event.text,
+		facets: event.facets,
+		channel: event.channel,
+		community,
+		author: event.author,
+		parent: existing?.parent,
+		attachments: event.attachments,
+		reactions: existing?.reactions ?? [],
+		createdAt: event.createdAt,
+		edited: event.edited,
+	};
+
+	const messages = existing
+		? snapshot.messages.map((m) => (m.uri === event.uri ? message : m))
+		: [...snapshot.messages, message].slice(-limit);
+
+	return { ...snapshot, messages, ts: Date.now() };
+};

--- a/packages/client/src/atproto/cache/messages-writer.ts
+++ b/packages/client/src/atproto/cache/messages-writer.ts
@@ -1,5 +1,6 @@
 import type { Colibri_MessageEvent } from "@colibri-social/lib";
 import type { Message } from "../xrpc/social/colibri/channel/listMessages";
+import { cursorFor } from "./messages-snapshot";
 import type { MessagesSnapshot } from "./schema";
 
 let openChannel: string | undefined;
@@ -18,7 +19,12 @@ export const applyMessageEvent = (
 	if (event.event === "delete") {
 		const remaining = snapshot.messages.filter((m) => m.uri !== event.uri);
 		if (remaining.length === snapshot.messages.length) return undefined;
-		return { ...snapshot, messages: remaining, ts: Date.now() };
+		return {
+			...snapshot,
+			messages: remaining,
+			cursor: cursorFor(remaining, snapshot.cursor),
+			ts: Date.now(),
+		};
 	}
 
 	const community = snapshot.messages[0]?.community;
@@ -40,9 +46,16 @@ export const applyMessageEvent = (
 		edited: event.edited,
 	};
 
-	const messages = existing
+	const next = existing
 		? snapshot.messages.map((m) => (m.uri === event.uri ? message : m))
-		: [...snapshot.messages, message].slice(-limit);
+		: [...snapshot.messages, message];
+	const messages = next.slice(-limit);
 
-	return { ...snapshot, messages, ts: Date.now() };
+	return {
+		...snapshot,
+		messages,
+		cursor: cursorFor(messages, snapshot.cursor),
+		hasMore: messages.length < next.length ? true : snapshot.hasMore,
+		ts: Date.now(),
+	};
 };

--- a/packages/client/src/atproto/cache/schema.ts
+++ b/packages/client/src/atproto/cache/schema.ts
@@ -15,6 +15,8 @@ export type CommunitySnapshot = CommunityDetail;
 export type MessagesSnapshot = {
 	messages: Message[];
 	readCursor?: string;
+	cursor?: string;
+	hasMore?: boolean;
 	ts: number;
 };
 

--- a/packages/client/src/atproto/cache/snapshot-scheduler.test.ts
+++ b/packages/client/src/atproto/cache/snapshot-scheduler.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+	createSnapshotScheduler,
+	type SnapshotClock,
+} from "./snapshot-scheduler";
+
+const MAX_INTERVAL_MS = 5000;
+const DEBOUNCE_MS = 400;
+
+const createFakeClock = () => {
+	let time = 1_000_000;
+	let nextId = 1;
+	const timers = new Map<number, { at: number; fn: () => void }>();
+
+	const clock: SnapshotClock<number> = {
+		now: () => time,
+		setTimer: (fn, ms) => {
+			const id = nextId++;
+			timers.set(id, { at: time + ms, fn });
+			return id;
+		},
+		clearTimer: (handle) => {
+			timers.delete(handle);
+		},
+	};
+
+	const advance = (ms: number) => {
+		const target = time + ms;
+		for (;;) {
+			let dueId: number | undefined;
+			let dueAt = Number.POSITIVE_INFINITY;
+			for (const [id, timer] of timers) {
+				if (timer.at <= target && timer.at < dueAt) {
+					dueId = id;
+					dueAt = timer.at;
+				}
+			}
+			if (dueId === undefined) break;
+			const due = timers.get(dueId);
+			timers.delete(dueId);
+			time = dueAt;
+			due?.fn();
+		}
+		time = target;
+	};
+
+	return { clock, advance, at: () => time };
+};
+
+const createHarness = () => {
+	const { clock, advance, at } = createFakeClock();
+	const writes: Array<{ payload: string; at: number }> = [];
+	const scheduler = createSnapshotScheduler<string, number>({
+		maxIntervalMs: MAX_INTERVAL_MS,
+		debounceMs: DEBOUNCE_MS,
+		clock,
+		write: (payload) => {
+			writes.push({ payload, at: at() });
+		},
+	});
+	return { scheduler, writes, advance, at };
+};
+
+describe("createSnapshotScheduler", () => {
+	it("writes the first snapshot immediately", () => {
+		const { scheduler, writes } = createHarness();
+
+		scheduler.schedule("a");
+
+		expect(writes.map((w) => w.payload)).toEqual(["a"]);
+	});
+
+	it("defers a snapshot scheduled shortly after a write", () => {
+		const { scheduler, writes, advance } = createHarness();
+
+		scheduler.schedule("a");
+		advance(100);
+		scheduler.schedule("b");
+
+		expect(writes).toHaveLength(1);
+
+		advance(DEBOUNCE_MS);
+
+		expect(writes.map((w) => w.payload)).toEqual(["a", "b"]);
+	});
+
+	it("keeps writing under sustained traffic faster than the debounce", () => {
+		const { scheduler, writes, advance } = createHarness();
+		const start = 1_000_000;
+
+		for (let i = 0; i < 120; i++) {
+			scheduler.schedule(`m${i}`);
+			advance(100);
+		}
+
+		expect(writes.length).toBeGreaterThan(1);
+
+		let previous = start;
+		for (const write of writes) {
+			expect(write.at - previous).toBeLessThanOrEqual(
+				MAX_INTERVAL_MS + DEBOUNCE_MS,
+			);
+			previous = write.at;
+		}
+	});
+
+	it("writes the trailing snapshot once traffic stops", () => {
+		const { scheduler, writes, advance } = createHarness();
+
+		scheduler.schedule("a");
+		for (let i = 0; i < 5; i++) {
+			advance(100);
+			scheduler.schedule(`b${i}`);
+		}
+		advance(DEBOUNCE_MS);
+
+		expect(writes.at(-1)?.payload).toBe("b4");
+	});
+
+	it("coalesces to the latest payload while deferring", () => {
+		const { scheduler, writes, advance } = createHarness();
+
+		scheduler.schedule("a");
+		advance(50);
+		scheduler.schedule("b");
+		advance(50);
+		scheduler.schedule("c");
+		advance(DEBOUNCE_MS);
+
+		expect(writes.map((w) => w.payload)).toEqual(["a", "c"]);
+	});
+
+	it("flushes a deferred snapshot on demand", () => {
+		const { scheduler, writes, advance } = createHarness();
+
+		scheduler.schedule("a");
+		advance(50);
+		scheduler.schedule("b");
+		scheduler.flush();
+
+		expect(writes.map((w) => w.payload)).toEqual(["a", "b"]);
+	});
+
+	it("does not write again after a flush cancelled the timer", () => {
+		const { scheduler, writes, advance } = createHarness();
+
+		scheduler.schedule("a");
+		advance(50);
+		scheduler.schedule("b");
+		scheduler.flush();
+		advance(DEBOUNCE_MS * 5);
+
+		expect(writes).toHaveLength(2);
+	});
+
+	it("is a no-op when flushing with nothing pending", () => {
+		const { scheduler, writes } = createHarness();
+
+		scheduler.flush();
+
+		expect(writes).toHaveLength(0);
+	});
+});

--- a/packages/client/src/atproto/cache/snapshot-scheduler.ts
+++ b/packages/client/src/atproto/cache/snapshot-scheduler.ts
@@ -1,0 +1,53 @@
+export type SnapshotClock<H> = {
+	now: () => number;
+	setTimer: (fn: () => void, ms: number) => H;
+	clearTimer: (handle: H) => void;
+};
+
+export type SnapshotScheduler<T> = {
+	schedule: (payload: T) => void;
+	flush: () => void;
+};
+
+export const realSnapshotClock: SnapshotClock<ReturnType<typeof setTimeout>> = {
+	now: () => Date.now(),
+	setTimer: (fn, ms) => setTimeout(fn, ms),
+	clearTimer: (handle) => {
+		clearTimeout(handle);
+	},
+};
+
+export const createSnapshotScheduler = <T, H>(options: {
+	maxIntervalMs: number;
+	debounceMs: number;
+	clock: SnapshotClock<H>;
+	write: (payload: T) => void;
+}): SnapshotScheduler<T> => {
+	let timer: H | undefined;
+	let pending: T | undefined;
+	let lastWriteAt = 0;
+
+	const flush = (): void => {
+		if (timer !== undefined) {
+			options.clock.clearTimer(timer);
+			timer = undefined;
+		}
+		const queued = pending;
+		if (queued === undefined) return;
+		pending = undefined;
+		lastWriteAt = options.clock.now();
+		options.write(queued);
+	};
+
+	const schedule = (payload: T): void => {
+		pending = payload;
+		if (options.clock.now() - lastWriteAt >= options.maxIntervalMs) {
+			flush();
+			return;
+		}
+		if (timer !== undefined) options.clock.clearTimer(timer);
+		timer = options.clock.setTimer(flush, options.debounceMs);
+	};
+
+	return { schedule, flush };
+};

--- a/packages/client/src/atproto/cache/store.ts
+++ b/packages/client/src/atproto/cache/store.ts
@@ -164,6 +164,23 @@ export const writeCommunity = (
 	snap: CommunitySnapshot,
 ): Promise<void> => write("community", communityKey(ns, uri), snap);
 
+const EVICT_EVERY_N_WRITES = 10;
+const writeCounts = new Map<StoreName, number>();
+
+const writeAndMaybeEvict = (
+	store: StoreName,
+	key: string,
+	value: unknown,
+	maxCount: number,
+): Promise<void> => {
+	return write(store, key, value).then(() => {
+		const seen = writeCounts.get(store) ?? 0;
+		writeCounts.set(store, seen + 1);
+		if (seen % EVICT_EVERY_N_WRITES !== 0) return undefined;
+		return evictOldest(store, maxCount);
+	});
+};
+
 export const readMessages = (
 	ns: string,
 	channelUri: string,
@@ -174,10 +191,14 @@ export const writeMessages = (
 	ns: string,
 	channelUri: string,
 	snap: MessagesSnapshot,
-): Promise<void> =>
-	write("messages", messagesKey(ns, channelUri), snap).then(() =>
-		evictOldest("messages", MAX_CHANNELS),
+): Promise<void> => {
+	return writeAndMaybeEvict(
+		"messages",
+		messagesKey(ns, channelUri),
+		snap,
+		MAX_CHANNELS,
 	);
+};
 
 export const readBskyPost = (
 	atUri: string,
@@ -188,9 +209,7 @@ export const writeBskyPost = (
 	atUri: string,
 	snap: BskyPostSnapshot,
 ): Promise<void> =>
-	write("bsky", bskyPostKey(atUri), snap).then(() =>
-		evictOldest("bsky", MAX_BSKY_ENTRIES),
-	);
+	writeAndMaybeEvict("bsky", bskyPostKey(atUri), snap, MAX_BSKY_ENTRIES);
 
 export const readBskyHandle = (
 	handle: string,
@@ -201,9 +220,7 @@ export const writeBskyHandle = (
 	handle: string,
 	snap: BskyHandleSnapshot,
 ): Promise<void> =>
-	write("bsky", bskyHandleKey(handle), snap).then(() =>
-		evictOldest("bsky", MAX_BSKY_ENTRIES),
-	);
+	writeAndMaybeEvict("bsky", bskyHandleKey(handle), snap, MAX_BSKY_ENTRIES);
 
 export const readBskyMuVerification = (
 	did: string,

--- a/packages/client/src/atproto/channel-prefetch.test.ts
+++ b/packages/client/src/atproto/channel-prefetch.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	channelUriFromPath,
+	prefetchChannelView,
+	resetChannelPrefetch,
+	takeChannelView,
+} from "./channel-prefetch";
+import type { XrpcClient } from "./xrpc";
+
+const DID = "did:plc:abc123";
+const CHANNEL = `at://${DID}/social.colibri.channel/general`;
+
+describe("channelUriFromPath", () => {
+	it("builds a channel URI from a short-form text path", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/text/general`)).toBe(CHANNEL);
+	});
+
+	it("accepts the full NSID form of the channel type", () => {
+		expect(
+			channelUriFromPath(`/app/c/${DID}/social.colibri.channel.text/general`),
+		).toBe(CHANNEL);
+	});
+
+	it("expands a bare community segment to the `self` rkey", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/text/general`)).toContain(DID);
+	});
+
+	it("keeps a non-self community rkey out of the channel URI", () => {
+		expect(channelUriFromPath(`/app/c/${DID}-myrkey/text/general`)).toBe(
+			CHANNEL,
+		);
+	});
+
+	it("ignores voice channels, which have no message list", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/voice/lounge`)).toBeUndefined();
+		expect(
+			channelUriFromPath(`/app/c/${DID}/social.colibri.channel.voice/lounge`),
+		).toBeUndefined();
+	});
+
+	it("ignores an unknown channel type", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/whiteboard/x`)).toBeUndefined();
+	});
+
+	it("ignores paths that are not channel deep links", () => {
+		expect(channelUriFromPath("/app")).toBeUndefined();
+		expect(channelUriFromPath(`/app/c/${DID}`)).toBeUndefined();
+		expect(channelUriFromPath("/app/login")).toBeUndefined();
+	});
+
+	it("tolerates trailing segments and query-free suffixes", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/text/general/extra`)).toBe(
+			CHANNEL,
+		);
+	});
+
+	it("decodes a percent-encoded rkey", () => {
+		expect(channelUriFromPath(`/app/c/${DID}/text/off%20topic`)).toBe(
+			`at://${DID}/social.colibri.channel/off topic`,
+		);
+	});
+});
+
+const clientReturning = (value: unknown): XrpcClient =>
+	({
+		social: {
+			colibri: {
+				channel: { getChannelView: vi.fn(async () => value) },
+			},
+		},
+	}) as unknown as XrpcClient;
+
+describe("prefetchChannelView / takeChannelView", () => {
+	beforeEach(() => {
+		resetChannelPrefetch();
+		vi.useRealTimers();
+	});
+
+	it("returns undefined when nothing was primed", () => {
+		expect(takeChannelView(CHANNEL)).toBeUndefined();
+	});
+
+	it("hands back the primed read", async () => {
+		const view = { ok: true, data: { messages: [] } };
+		prefetchChannelView(clientReturning(view), CHANNEL);
+		await expect(takeChannelView(CHANNEL)).resolves.toEqual(view);
+	});
+
+	it("only issues one request for repeat primes of the same channel", () => {
+		const client = clientReturning({ ok: true, data: { messages: [] } });
+		prefetchChannelView(client, CHANNEL);
+		prefetchChannelView(client, CHANNEL);
+		expect(client.social.colibri.channel.getChannelView).toHaveBeenCalledTimes(
+			1,
+		);
+	});
+
+	it("forgets the entry once taken, so a remount refetches", async () => {
+		prefetchChannelView(
+			clientReturning({ ok: true, data: { messages: [] } }),
+			CHANNEL,
+		);
+		await takeChannelView(CHANNEL);
+		expect(takeChannelView(CHANNEL)).toBeUndefined();
+	});
+
+	it("discards a payload primed too long ago", () => {
+		vi.useFakeTimers();
+		prefetchChannelView(
+			clientReturning({ ok: true, data: { messages: [] } }),
+			CHANNEL,
+		);
+		vi.advanceTimersByTime(21_000);
+		expect(takeChannelView(CHANNEL)).toBeUndefined();
+	});
+
+	it("resolves to undefined rather than rejecting when the read throws", async () => {
+		const client = {
+			social: {
+				colibri: {
+					channel: {
+						getChannelView: vi.fn(async () => {
+							throw new Error("offline");
+						}),
+					},
+				},
+			},
+		} as unknown as XrpcClient;
+		prefetchChannelView(client, CHANNEL);
+		await expect(takeChannelView(CHANNEL)).resolves.toBeUndefined();
+	});
+
+	it("evicts the oldest entry past the cap", async () => {
+		const client = clientReturning({ ok: true, data: { messages: [] } });
+		prefetchChannelView(client, `${CHANNEL}-1`);
+		prefetchChannelView(client, `${CHANNEL}-2`);
+		prefetchChannelView(client, `${CHANNEL}-3`);
+		expect(takeChannelView(`${CHANNEL}-1`)).toBeUndefined();
+		await expect(takeChannelView(`${CHANNEL}-3`)).resolves.toBeDefined();
+	});
+});

--- a/packages/client/src/atproto/channel-prefetch.ts
+++ b/packages/client/src/atproto/channel-prefetch.ts
@@ -60,6 +60,10 @@ export const prefetchChannelView = (xrpc: XrpcClient, uri: string): void => {
 				code: failure.code,
 			});
 			return undefined;
+		})
+		.then((result) => {
+			markBoot("prefetch:settled");
+			return result;
 		});
 
 	inflight.set(uri, { promise, startedAt: Date.now() });

--- a/packages/client/src/atproto/channel-prefetch.ts
+++ b/packages/client/src/atproto/channel-prefetch.ts
@@ -1,0 +1,94 @@
+import { classifyThrown } from "../errors/classify";
+import { AtURI, toRecordUri } from "../utils/at-uri";
+import { lastViewedChannelPath } from "../utils/last-viewed-channel";
+import { createLogger } from "../utils/logger";
+import { markBoot } from "../utils/perf";
+import { urlSegmentToUri } from "./community-uri-to-url-compatible";
+import type { XrpcClient } from "./xrpc";
+import type { XrpcResult } from "./xrpc/result";
+import type { Response as ChannelView } from "./xrpc/social/colibri/channel/getChannelView";
+
+const log = createLogger("channel-prefetch");
+
+const PREFETCH_LIMIT = 50;
+
+const MAX_AGE_MS = 20_000;
+
+const MAX_ENTRIES = 2;
+
+const TEXT_CHANNEL_TYPES = ["text", "social.colibri.channel.text"];
+
+const CHANNEL_PATH = /^\/app\/c\/([^/]+)\/([^/]+)\/([^/]+)/;
+
+type Entry = {
+	promise: Promise<XrpcResult<ChannelView> | undefined>;
+	startedAt: number;
+};
+
+const inflight = new Map<string, Entry>();
+
+export const channelUriFromPath = (pathname: string): string | undefined => {
+	const match = CHANNEL_PATH.exec(pathname);
+	if (!match) return undefined;
+
+	const [, communitySegment, channelType, rkey] = match;
+	if (!communitySegment || !channelType || !rkey) return undefined;
+	if (!TEXT_CHANNEL_TYPES.includes(channelType)) return undefined;
+
+	const did = AtURI.parseAtURI(urlSegmentToUri(communitySegment)).did;
+	if (!did) return undefined;
+
+	return toRecordUri(did, "social.colibri.channel", decodeURIComponent(rkey));
+};
+
+export const prefetchChannelView = (xrpc: XrpcClient, uri: string): void => {
+	if (inflight.has(uri)) return;
+	if (inflight.size >= MAX_ENTRIES) {
+		const oldest = [...inflight.entries()].sort(
+			(a, b) => a[1].startedAt - b[1].startedAt,
+		)[0];
+		if (oldest) inflight.delete(oldest[0]);
+	}
+
+	const promise = xrpc.social.colibri.channel
+		.getChannelView(uri, PREFETCH_LIMIT)
+		.catch((err: unknown) => {
+			const failure = classifyThrown(err, {
+				method: "channel.getChannelView",
+			});
+			log.debug("prefetch failed, the channel will fetch normally", {
+				code: failure.code,
+			});
+			return undefined;
+		});
+
+	inflight.set(uri, { promise, startedAt: Date.now() });
+};
+
+export const takeChannelView = (
+	uri: string,
+): Promise<XrpcResult<ChannelView> | undefined> | undefined => {
+	const entry = inflight.get(uri);
+	if (!entry) return undefined;
+	inflight.delete(uri);
+	if (Date.now() - entry.startedAt > MAX_AGE_MS) return undefined;
+	return entry.promise;
+};
+
+export const primeFromLocation = (xrpc: XrpcClient): void => {
+	if (typeof window === "undefined") return;
+	const path = window.location.pathname;
+	const uri =
+		channelUriFromPath(path) ??
+		(() => {
+			const fallback = lastViewedChannelPath(path);
+			return fallback ? channelUriFromPath(fallback) : undefined;
+		})();
+	if (!uri) return;
+	prefetchChannelView(xrpc, uri);
+	markBoot("prefetch:issued");
+};
+
+export const resetChannelPrefetch = (): void => {
+	inflight.clear();
+};

--- a/packages/client/src/atproto/outbox/outbox.ts
+++ b/packages/client/src/atproto/outbox/outbox.ts
@@ -24,8 +24,17 @@ const RETRY_BASE_MS = 2_000;
 const RETRY_MAX_MS = 60_000;
 
 const [pendingCount, setPendingCount] = createSignal(0);
+const [outboxRevision, setOutboxRevision] = createSignal(0);
 
-export { pendingCount };
+export { outboxRevision, pendingCount };
+
+export type QueuedRecord = {
+	uri: string;
+	rkey: string;
+	kind: "create" | "put";
+	record: Record<string, unknown>;
+	createdAt: number;
+};
 
 let agent: Agent | null = null;
 let owner: string | null = null;
@@ -62,10 +71,29 @@ const emitSent = (uri: string, collection: string) => {
 const isOffline = () =>
 	typeof navigator !== "undefined" && navigator.onLine === false;
 
-const sync = () => setPendingCount(queue.length);
+const sync = () => {
+	setPendingCount(queue.length);
+	setOutboxRevision((r) => r + 1);
+};
 
 const buildUri = (repo: string, collection: string, rkey: string) =>
 	`at://${repo}/${collection}/${rkey}`;
+
+export const queuedRecords = (collection: string): QueuedRecord[] =>
+	queue.flatMap((entry) => {
+		const k = entry.kind;
+		if (k.t !== "create" && k.t !== "put") return [];
+		if (k.collection !== collection) return [];
+		return [
+			{
+				uri: buildUri(k.repo, k.collection, k.rkey),
+				rkey: k.rkey,
+				kind: k.t,
+				record: k.record,
+				createdAt: entry.createdAt,
+			},
+		];
+	});
 
 const toRecord = (entry: OutboxEntry): OutboxRecord => {
 	const { seq: _seq, ...rest } = entry;
@@ -283,6 +311,7 @@ export const enqueuePut = async (
 		existing.kind.record = record;
 		existing.attempts = 0;
 		await outboxUpdate(existing.seq, toRecord(existing));
+		sync();
 		scheduleFlush();
 		return { uri: buildUri(repo, collection, rkey) };
 	}

--- a/packages/client/src/atproto/outbox/rehydrate.test.ts
+++ b/packages/client/src/atproto/outbox/rehydrate.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type {
+	Message,
+	PendingMessage,
+} from "../xrpc/social/colibri/channel/listMessages";
+import type { QueuedRecord } from "./outbox";
+import { rehydrateQueuedMessages } from "./rehydrate";
+
+const DID = "did:plc:abc123";
+const CHANNEL = `at://${DID}/social.colibri.channel/general`;
+const OTHER_CHANNEL = `at://${DID}/social.colibri.channel/random`;
+const COMMUNITY = `at://${DID}/social.colibri.community/self`;
+
+const author = {
+	did: DID,
+	handle: "someone.example",
+	data: { displayName: "Someone" },
+} as unknown as Message["author"];
+
+const message = (rkey: string, text = "hello"): Message => ({
+	uri: `at://${DID}/social.colibri.message/${rkey}`,
+	text,
+	facets: [],
+	channel: CHANNEL,
+	community: COMMUNITY,
+	author,
+	attachments: [],
+	reactions: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	edited: false,
+});
+
+const queued = (
+	rkey: string,
+	kind: "create" | "put",
+	record: Record<string, unknown>,
+	createdAt = 1,
+): QueuedRecord => ({
+	uri: `at://${DID}/social.colibri.message/${rkey}`,
+	rkey,
+	kind,
+	record: { channel: CHANNEL, ...record },
+	createdAt,
+});
+
+const run = (
+	queuedRecords: QueuedRecord[],
+	existing: (Message | PendingMessage)[],
+) =>
+	rehydrateQueuedMessages({
+		channelUri: CHANNEL,
+		community: COMMUNITY,
+		author,
+		queued: queuedRecords,
+		existing,
+	});
+
+describe("rehydrateQueuedMessages", () => {
+	it("appends a queued create that never reached the list", () => {
+		const result = run(
+			[queued("m2", "create", { text: "unsent", createdAt: "2026-01-02" })],
+			[message("m1")],
+		);
+
+		expect(result).toHaveLength(2);
+		const added = result?.[1] as PendingMessage;
+		expect(added.text).toBe("unsent");
+		expect(added.hash).toBe("outbox:m2");
+		expect(added.community).toBe(COMMUNITY);
+		expect(added.channel).toBe(CHANNEL);
+	});
+
+	it("ignores queued writes for another channel", () => {
+		const entry = queued("m2", "create", { text: "elsewhere" });
+		entry.record.channel = OTHER_CHANNEL;
+
+		expect(run([entry], [message("m1")])).toBeUndefined();
+	});
+
+	it("does not duplicate a create already present in the list", () => {
+		expect(
+			run([queued("m1", "create", { text: "hello" })], [message("m1")]),
+		).toBeUndefined();
+	});
+
+	it("orders multiple additions by their queue timestamp", () => {
+		const result = run(
+			[
+				queued("m3", "create", { text: "second" }, 20),
+				queued("m2", "create", { text: "first" }, 10),
+			],
+			[],
+		);
+
+		expect(result?.map((m) => m.text)).toEqual(["first", "second"]);
+	});
+
+	it("resolves a reply parent from the existing list", () => {
+		const parent = message("m1");
+		const result = run(
+			[queued("m2", "create", { text: "reply", parent: parent.uri })],
+			[parent],
+		);
+
+		expect((result?.[1] as PendingMessage).parent?.uri).toBe(parent.uri);
+	});
+
+	it("leaves the parent undefined when it is not loaded", () => {
+		const result = run(
+			[
+				queued("m2", "create", {
+					text: "reply",
+					parent: `at://${DID}/social.colibri.message/gone`,
+				}),
+			],
+			[],
+		);
+
+		expect((result?.[0] as PendingMessage).parent).toBeUndefined();
+	});
+
+	it("applies a queued edit over the confirmed row", () => {
+		const result = run(
+			[queued("m1", "put", { text: "edited" })],
+			[message("m1")],
+		);
+
+		expect(result?.[0]?.text).toBe("edited");
+		expect(result?.[0]?.edited).toBe(true);
+		expect("hash" in (result?.[0] ?? {})).toBe(false);
+	});
+
+	it("ignores a queued edit for a message that is not loaded", () => {
+		expect(
+			run([queued("m9", "put", { text: "edited" })], [message("m1")]),
+		).toBeUndefined();
+	});
+
+	it("converges so a second pass reports no further change", () => {
+		const first = run(
+			[
+				queued("m1", "put", { text: "edited" }),
+				queued("m2", "create", { text: "unsent" }),
+			],
+			[message("m1")],
+		);
+		expect(first).toBeDefined();
+
+		const second = run(
+			[
+				queued("m1", "put", { text: "edited" }),
+				queued("m2", "create", { text: "unsent" }),
+			],
+			first ?? [],
+		);
+
+		expect(second).toBeUndefined();
+	});
+
+	it("returns undefined when nothing is queued", () => {
+		expect(run([], [message("m1")])).toBeUndefined();
+	});
+
+	it("tolerates a record with missing fields", () => {
+		const result = run([queued("m2", "create", {})], []);
+
+		expect(result?.[0]?.text).toBe("");
+		expect(result?.[0]?.facets).toEqual([]);
+		expect(result?.[0]?.attachments).toEqual([]);
+	});
+});

--- a/packages/client/src/atproto/outbox/rehydrate.test.ts
+++ b/packages/client/src/atproto/outbox/rehydrate.test.ts
@@ -102,7 +102,9 @@ describe("rehydrateQueuedMessages", () => {
 			[parent],
 		);
 
-		expect((result?.[1] as PendingMessage).parent?.uri).toBe(parent.uri);
+		const added = result?.[1] as PendingMessage | undefined;
+		expect(added).toBeDefined();
+		expect(added?.parent?.uri).toBe(parent.uri);
 	});
 
 	it("leaves the parent undefined when it is not loaded", () => {
@@ -116,7 +118,9 @@ describe("rehydrateQueuedMessages", () => {
 			[],
 		);
 
-		expect((result?.[0] as PendingMessage).parent).toBeUndefined();
+		const added = result?.[0] as PendingMessage | undefined;
+		expect(added).toBeDefined();
+		expect(added?.parent).toBeUndefined();
 	});
 
 	it("applies a queued edit over the confirmed row", () => {

--- a/packages/client/src/atproto/outbox/rehydrate.ts
+++ b/packages/client/src/atproto/outbox/rehydrate.ts
@@ -1,0 +1,95 @@
+import type { ColibriRichTextFacet } from "@colibri-social/lib";
+import type {
+	Message,
+	PendingMessage,
+} from "../xrpc/social/colibri/channel/listMessages";
+import type { QueuedRecord } from "./outbox";
+
+const asString = (value: unknown): string | undefined =>
+	typeof value === "string" ? value : undefined;
+
+const asFacets = (value: unknown): ColibriRichTextFacet[] =>
+	Array.isArray(value) ? (value as ColibriRichTextFacet[]) : [];
+
+const asAttachments = (value: unknown): Message["attachments"] =>
+	Array.isArray(value) ? (value as Message["attachments"]) : [];
+
+const toPendingMessage = (
+	queued: QueuedRecord,
+	context: {
+		channelUri: string;
+		community: string;
+		author: Message["author"];
+		parentOf: (uri: string) => Message | undefined;
+	},
+): PendingMessage => {
+	const parentUri = asString(queued.record.parent);
+	return {
+		hash: `outbox:${queued.rkey}`,
+		uri: queued.uri,
+		text: asString(queued.record.text) ?? "",
+		facets: asFacets(queued.record.facets),
+		channel: context.channelUri,
+		community: context.community,
+		author: context.author,
+		parent: parentUri ? context.parentOf(parentUri) : undefined,
+		attachments: asAttachments(queued.record.attachments),
+		reactions: [],
+		createdAt: asString(queued.record.createdAt) ?? new Date(0).toISOString(),
+		edited: false,
+	};
+};
+
+export const rehydrateQueuedMessages = (input: {
+	channelUri: string;
+	community: string;
+	author: Message["author"];
+	queued: QueuedRecord[];
+	existing: (Message | PendingMessage)[];
+}): (Message | PendingMessage)[] | undefined => {
+	const mine = input.queued.filter(
+		(q) => asString(q.record.channel) === input.channelUri,
+	);
+	if (mine.length === 0) return undefined;
+
+	const byUri = new Map(input.existing.map((m) => [m.uri, m]));
+	const parentOf = (uri: string) => {
+		const found = byUri.get(uri);
+		return found && !("hash" in found) ? found : undefined;
+	};
+
+	const edits = new Map(
+		mine
+			.filter((q) => q.kind === "put" && byUri.has(q.uri))
+			.map((q) => [q.uri, q]),
+	);
+
+	const additions = mine
+		.filter((q) => q.kind === "create" && !byUri.has(q.uri))
+		.sort((a, b) => a.createdAt - b.createdAt)
+		.map((q) =>
+			toPendingMessage(q, {
+				channelUri: input.channelUri,
+				community: input.community,
+				author: input.author,
+				parentOf,
+			}),
+		);
+
+	if (additions.length === 0 && edits.size === 0) return undefined;
+
+	const reconciled = input.existing.map((m) => {
+		const edit = edits.get(m.uri);
+		if (!edit) return m;
+		const text = asString(edit.record.text) ?? m.text;
+		const facets = asFacets(edit.record.facets);
+		if (text === m.text && m.edited) return m;
+		return { ...m, text, facets, edited: true };
+	});
+
+	const changed =
+		additions.length > 0 || reconciled.some((m, i) => m !== input.existing[i]);
+	if (!changed) return undefined;
+
+	return [...reconciled, ...additions];
+};

--- a/packages/client/src/components/app/MessageSnapshotWriter.tsx
+++ b/packages/client/src/components/app/MessageSnapshotWriter.tsx
@@ -1,0 +1,93 @@
+import { type Component, onCleanup, onMount } from "solid-js";
+import { namespace } from "../../atproto/cache/keys";
+import {
+	applyMessageEvent,
+	isOpenChannel,
+} from "../../atproto/cache/messages-writer";
+import type { MessagesSnapshot } from "../../atproto/cache/schema";
+import {
+	cacheEnabled,
+	readMessages,
+	writeMessages,
+} from "../../atproto/cache/store";
+import { PAGE_SIZE } from "../../contexts/Channel";
+import { useSocketContext } from "../../contexts/Socket";
+import { useUserContext } from "../../contexts/User";
+import { classifyThrown } from "../../errors/classify";
+import { getAppViewDid } from "../../utils/appview";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("messages-writer");
+
+const FLUSH_INTERVAL_MS = 5000;
+
+export const MessageSnapshotWriter: Component = () => {
+	const socket = useSocketContext();
+	const user = useUserContext();
+
+	const pending = new Map<string, MessagesSnapshot>();
+	const chains = new Map<string, Promise<void>>();
+	let flushTimer: ReturnType<typeof setInterval> | undefined;
+
+	const ns = () => namespace(getAppViewDid(), user.did);
+
+	const flush = () => {
+		if (pending.size === 0) return;
+		const batch = [...pending.entries()];
+		pending.clear();
+		for (const [uri, snap] of batch) {
+			void writeMessages(ns(), uri, snap);
+		}
+	};
+
+	const onHidden = () => {
+		if (document.visibilityState === "hidden") flush();
+	};
+
+	onMount(() => {
+		if (!cacheEnabled()) return;
+
+		const unsubscribe = socket.onEvent((event) => {
+			if (event.type !== "message_event") return;
+			const data = event.data;
+			if (!data?.channel) return;
+
+			const uri = data.channel;
+			if (isOpenChannel(uri)) return;
+
+			const fold = async () => {
+				try {
+					const current = pending.get(uri) ?? (await readMessages(ns(), uri));
+					if (!current) return;
+					if (isOpenChannel(uri)) return;
+					const next = applyMessageEvent(current, data, PAGE_SIZE);
+					if (next) pending.set(uri, next);
+				} catch (err) {
+					log.warn("could not fold an event into a snapshot", {
+						code: classifyThrown(err).code,
+					});
+				}
+			};
+
+			const chain = (chains.get(uri) ?? Promise.resolve()).then(fold);
+			chains.set(uri, chain);
+			void chain.finally(() => {
+				if (chains.get(uri) === chain) chains.delete(uri);
+			});
+		});
+
+		flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
+		document.addEventListener("visibilitychange", onHidden);
+		window.addEventListener("pagehide", flush);
+
+		onCleanup(() => {
+			unsubscribe();
+			if (flushTimer) clearInterval(flushTimer);
+			document.removeEventListener("visibilitychange", onHidden);
+			window.removeEventListener("pagehide", flush);
+			flush();
+		});
+	});
+
+	return null;
+};

--- a/packages/client/src/components/app/onboarding/ProfileGate.tsx
+++ b/packages/client/src/components/app/onboarding/ProfileGate.tsx
@@ -1,6 +1,7 @@
 import { createResource, Match, type ParentComponent, Switch } from "solid-js";
 import { useUserContext } from "../../../contexts/User";
 import { classifyThrown, isRecordNotFound } from "../../../errors/classify";
+import { markBoot } from "../../../utils/perf";
 import { AppLoadingScreen } from "../../AppLoadingScreen";
 import { ErrorState } from "../../ErrorState";
 import { ProfileSetupModal } from "./ProfileSetupModal";
@@ -18,8 +19,26 @@ type GateState = {
 	returning: boolean;
 };
 
+const seenKey = (did: string) => `colibri:profile-ok:${did}`;
+
+const hasSeenProfile = (did: string): boolean => {
+	try {
+		return localStorage.getItem(seenKey(did)) === "1";
+	} catch {
+		return false;
+	}
+};
+
+const rememberProfile = (did: string, present: boolean): void => {
+	try {
+		if (present) localStorage.setItem(seenKey(did), "1");
+		else localStorage.removeItem(seenKey(did));
+	} catch {}
+};
+
 export const ProfileGate: ParentComponent = (props) => {
 	const user = useUserContext();
+	const skipBlocking = hasSeenProfile(user.did);
 
 	const recordExists = async (collection: string): Promise<boolean> => {
 		try {
@@ -56,27 +75,36 @@ export const ProfileGate: ParentComponent = (props) => {
 				recordExists("app.bsky.actor.profile"),
 				isReturning(),
 			]);
+			rememberProfile(user.did, hasColibri);
+			markBoot("profilegate:ready");
 			return { needsSetup: !hasColibri, hasBluesky, returning };
 		},
 	);
 
+	const needsSetup = () => gate()?.needsSetup ?? false;
+
 	return (
 		<Switch>
-			<Match when={gate.loading}>
+			<Match when={gate.loading && !skipBlocking}>
 				<AppLoadingScreen message="Checking your profile..." />
 			</Match>
-			<Match when={gate.error !== undefined}>
+			<Match when={gate.error !== undefined && !skipBlocking}>
 				<ErrorState error={gate.error} retry={() => void refetch()} />
 			</Match>
-			<Match when={gate()?.needsSetup}>
+			<Match when={needsSetup()}>
 				<ProfileSetupModal
 					open
 					hasBlueskyProfile={gate()?.hasBluesky ?? false}
 					returning={gate()?.returning ?? false}
-					onComplete={() => mutate((prev) => ({ ...prev!, needsSetup: false }))}
+					onComplete={() => {
+						rememberProfile(user.did, true);
+						mutate((prev) => ({ ...prev!, needsSetup: false }));
+					}}
 				/>
 			</Match>
-			<Match when={gate() && !gate()!.needsSetup}>{props.children}</Match>
+			<Match when={skipBlocking || (gate() && !gate()!.needsSetup)}>
+				{props.children}
+			</Match>
 		</Switch>
 	);
 };

--- a/packages/client/src/components/app/onboarding/ScopeGate.tsx
+++ b/packages/client/src/components/app/onboarding/ScopeGate.tsx
@@ -12,7 +12,7 @@ export const ScopeGate: ParentComponent = (props) => {
 
 	if (!auth?.loggedIn) return <>{props.children}</>;
 
-	const missing = createMemo(() => getMissingScopeSets(auth.grantedScopes));
+	const missing = createMemo(() => getMissingScopeSets(auth.grantedScopes()));
 
 	const needsReauth = createMemo(() => {
 		if (missing().length === 0) {

--- a/packages/client/src/components/app/settings/AboutPage.tsx
+++ b/packages/client/src/components/app/settings/AboutPage.tsx
@@ -88,7 +88,7 @@ export const AboutPage: Component = () => {
 				did: user.did,
 				handle: user.handle,
 				pdsHost: user.atproto.pdsHost ?? "unknown",
-				grantedScopes: auth?.loggedIn ? auth.grantedScopes : undefined,
+				grantedScopes: auth?.loggedIn ? auth.grantedScopes() : undefined,
 				socketStatus: socket.status(),
 				nativeNotifications: preferences().nativeNotifications,
 				experiments: preferences().experiments,

--- a/packages/client/src/components/app/settings/AboutPage.tsx
+++ b/packages/client/src/components/app/settings/AboutPage.tsx
@@ -87,7 +87,7 @@ export const AboutPage: Component = () => {
 			await collectDiagnostics({
 				did: user.did,
 				handle: user.handle,
-				pdsHost: user.atproto.pdsHost,
+				pdsHost: user.atproto.pdsHost ?? "unknown",
 				grantedScopes: auth?.loggedIn ? auth.grantedScopes : undefined,
 				socketStatus: socket.status(),
 				nativeNotifications: preferences().nativeNotifications,

--- a/packages/client/src/contexts/Auth.tsx
+++ b/packages/client/src/contexts/Auth.tsx
@@ -8,9 +8,15 @@ import {
 	useContext,
 } from "solid-js";
 import { type Client, getClient } from "../atproto/auth";
+import { primeFromLocation } from "../atproto/channel-prefetch";
+import { XrpcClient } from "../atproto/xrpc";
 import { AppLoadingScreen } from "../components/AppLoadingScreen";
 import { AppViewUnreachableModal } from "../components/app/AppViewUnreachableModal";
-import { getAppViewHost, verifyColibriAppView } from "../utils/appview";
+import {
+	getAppViewHost,
+	getAppViewServiceRef,
+	verifyColibriAppView,
+} from "../utils/appview";
 import { reportPdsStatus } from "../utils/dev-diagnostics";
 import { markBoot } from "../utils/perf";
 
@@ -21,6 +27,12 @@ export const AuthContextProvider: ParentComponent = (props) => {
 
 	createEffect(() => {
 		if (!client.loading) markBoot("auth:ready");
+	});
+
+	createEffect(() => {
+		const resolved = client();
+		if (!resolved?.loggedIn) return;
+		primeFromLocation(new XrpcClient(getAppViewServiceRef(), resolved.agent));
 	});
 
 	// An AppView with no usable PDS serves every read fine and fails every

--- a/packages/client/src/contexts/Channel.tsx
+++ b/packages/client/src/contexts/Channel.tsx
@@ -10,12 +10,25 @@ import {
 	onCleanup,
 	onMount,
 	type ParentComponent,
+	untrack,
 	useContext,
 } from "solid-js";
 import { toast } from "somoto";
 import { namespace } from "../atproto/cache/keys";
+import {
+	buildMessagesSnapshot,
+	isSnapshotPaintable,
+	restoreMessagesSnapshot,
+	rkeyOf,
+	shouldWriteSnapshot,
+	snapshotAgeMs,
+} from "../atproto/cache/messages-snapshot";
 import { registerOpenChannel } from "../atproto/cache/messages-writer";
 import type { MessagesSnapshot } from "../atproto/cache/schema";
+import {
+	createSnapshotScheduler,
+	realSnapshotClock,
+} from "../atproto/cache/snapshot-scheduler";
 import {
 	cacheEnabled,
 	readMessages,
@@ -23,7 +36,13 @@ import {
 } from "../atproto/cache/store";
 import { takeChannelView } from "../atproto/channel-prefetch";
 import { communityUriToUrlCompatible } from "../atproto/community-uri-to-url-compatible";
-import { enqueuePut, onOutboxSent } from "../atproto/outbox/outbox";
+import {
+	enqueuePut,
+	onOutboxSent,
+	outboxRevision,
+	queuedRecords,
+} from "../atproto/outbox/outbox";
+import { rehydrateQueuedMessages } from "../atproto/outbox/rehydrate";
 import { writeReadCursor } from "../atproto/read-cursor";
 import type {
 	Message,
@@ -51,10 +70,6 @@ import { useUserContext } from "./User";
 const TYPING_HOLD_MS = 5000;
 
 export const PAGE_SIZE = 50;
-
-const MESSAGES_HARD_TTL_MS = 24 * 60 * 60 * 1000;
-
-export const MESSAGES_STALE_HINT_MS = 60_000;
 
 const CACHE_WRITE_MAX_INTERVAL_MS = 5000;
 
@@ -224,8 +239,6 @@ export type ChannelContextValue = {
 const log = createLogger("channel");
 
 export const ChannelContext = createContext<ChannelContextValue>();
-
-const rkeyOf = (uri: string): string => uri.split("/").pop() ?? "";
 
 export const ChannelContextProvider: ParentComponent<{
 	channel: Accessor<Channel | undefined>;
@@ -413,7 +426,7 @@ export const ChannelContextProvider: ParentComponent<{
 				setMessages([...ordered, ...stillPending]);
 				const oldest = ordered[0];
 				if (oldest) setCursor(rkeyOf(oldest.uri));
-				if (ordered.length < PAGE_SIZE) setHasMore(false);
+				setHasMore(ordered.length >= PAGE_SIZE);
 				setReadCursorUri(channel?.readCursor?.cursor);
 				setInitialUnseen((channel?.unseen ?? []).map((n) => n.messageUri));
 				setHydratedFromNetwork(true);
@@ -433,23 +446,19 @@ export const ChannelContextProvider: ParentComponent<{
 		}
 	};
 
-	let cacheWriteTimer: ReturnType<typeof setTimeout> | undefined;
-	let pendingSnapshot:
-		| { ns: string; uri: string; snap: MessagesSnapshot }
-		| undefined;
-	let lastCacheWriteAt = 0;
+	const snapshotWrites = createSnapshotScheduler<
+		{ ns: string; uri: string; snap: MessagesSnapshot },
+		ReturnType<typeof setTimeout>
+	>({
+		maxIntervalMs: CACHE_WRITE_MAX_INTERVAL_MS,
+		debounceMs: CACHE_WRITE_DEBOUNCE_MS,
+		clock: realSnapshotClock,
+		write: (queued) => {
+			void writeMessages(queued.ns, queued.uri, queued.snap);
+		},
+	});
 
-	const flushSnapshot = () => {
-		if (cacheWriteTimer) {
-			clearTimeout(cacheWriteTimer);
-			cacheWriteTimer = undefined;
-		}
-		const queued = pendingSnapshot;
-		if (!queued) return;
-		pendingSnapshot = undefined;
-		lastCacheWriteAt = Date.now();
-		void writeMessages(queued.ns, queued.uri, queued.snap);
-	};
+	const flushSnapshot = () => snapshotWrites.flush();
 
 	// Reset state and seed the first page whenever the channel URI changes
 	// (including the initial mount). `on` makes the dependency explicit.
@@ -473,14 +482,15 @@ export const ChannelContextProvider: ParentComponent<{
 			if (!cacheEnabled() || !uri) return;
 			const cached = await readMessages(ns(), uri);
 			if (!cached) return;
-			const age = Date.now() - cached.ts;
-			if (age > MESSAGES_HARD_TTL_MS) return;
+			const age = snapshotAgeMs(cached, Date.now());
+			if (!isSnapshotPaintable(age)) return;
 			if (uri !== channelUri() || hydratedFromNetwork()) return;
 			if (messages().length > 0) return;
+			const restored = restoreMessagesSnapshot(cached);
 			batch(() => {
 				setMessages(cached.messages);
-				const oldest = cached.messages[0];
-				if (oldest) setCursor(rkeyOf(oldest.uri));
+				if (restored.cursor) setCursor(restored.cursor);
+				if (restored.hasMore !== undefined) setHasMore(restored.hasMore);
 				setReadCursorUri(cached.readCursor);
 				setSnapshotAge(age);
 				setInitialLoading(false);
@@ -491,32 +501,46 @@ export const ChannelContextProvider: ParentComponent<{
 
 	createEffect(() => {
 		const uri = channelUri();
+		outboxRevision();
+		if (!uri || initialLoading()) return;
+		untrack(() => {
+			const reconciled = rehydrateQueuedMessages({
+				channelUri: uri,
+				community: community().community.uri,
+				author: {
+					did: user.did,
+					handle: user.handle.replaceAll("at://", ""),
+					data: user.data,
+				},
+				queued: queuedRecords("social.colibri.message"),
+				existing: messages(),
+			});
+			if (reconciled) setMessages(reconciled);
+		});
+	});
+
+	createEffect(() => {
+		const uri = channelUri();
 		const confirmed = messages().filter(
 			(m) => !("hash" in m) && m.uri.startsWith("at://"),
 		);
-		if (
-			!cacheEnabled() ||
-			!uri ||
-			!hydratedFromNetwork() ||
-			confirmed.length === 0
-		) {
-			return;
-		}
-		pendingSnapshot = {
+		const gate = {
+			cacheEnabled: cacheEnabled(),
+			channelUri: uri,
+			hydratedFromNetwork: hydratedFromNetwork(),
+			confirmedCount: confirmed.length,
+		};
+		if (!shouldWriteSnapshot(gate)) return;
+		snapshotWrites.schedule({
 			ns: ns(),
 			uri,
-			snap: {
-				messages: confirmed.slice(-PAGE_SIZE),
+			snap: buildMessagesSnapshot(confirmed, {
 				readCursor: readCursorUri(),
-				ts: Date.now(),
-			},
-		};
-		if (Date.now() - lastCacheWriteAt >= CACHE_WRITE_MAX_INTERVAL_MS) {
-			flushSnapshot();
-			return;
-		}
-		if (cacheWriteTimer) clearTimeout(cacheWriteTimer);
-		cacheWriteTimer = setTimeout(flushSnapshot, CACHE_WRITE_DEBOUNCE_MS);
+				hasMore: hasMore(),
+				limit: PAGE_SIZE,
+				now: Date.now(),
+			}),
+		});
 	});
 
 	const onHidden = () => {
@@ -562,7 +586,11 @@ export const ChannelContextProvider: ParentComponent<{
 	// ---------------------------------------------------------------------------
 
 	const addPendingMessage = (msg: PendingMessage) => {
-		setMessages((prev) => [...prev, msg]);
+		setMessages((prev) =>
+			prev.some((m) => m.uri === msg.uri)
+				? prev.map((m) => (m.uri === msg.uri ? msg : m))
+				: [...prev, msg],
+		);
 		setReadCursorUri(undefined);
 		setOutgoingMessage((n) => n + 1);
 	};

--- a/packages/client/src/contexts/Channel.tsx
+++ b/packages/client/src/contexts/Channel.tsx
@@ -14,11 +14,14 @@ import {
 } from "solid-js";
 import { toast } from "somoto";
 import { namespace } from "../atproto/cache/keys";
+import { registerOpenChannel } from "../atproto/cache/messages-writer";
+import type { MessagesSnapshot } from "../atproto/cache/schema";
 import {
 	cacheEnabled,
 	readMessages,
 	writeMessages,
 } from "../atproto/cache/store";
+import { takeChannelView } from "../atproto/channel-prefetch";
 import { communityUriToUrlCompatible } from "../atproto/community-uri-to-url-compatible";
 import { enqueuePut, onOutboxSent } from "../atproto/outbox/outbox";
 import { writeReadCursor } from "../atproto/read-cursor";
@@ -47,7 +50,17 @@ import { useUserContext } from "./User";
  */
 const TYPING_HOLD_MS = 5000;
 
-const PAGE_SIZE = 50;
+export const PAGE_SIZE = 50;
+
+const MESSAGES_HARD_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const MESSAGES_STALE_HINT_MS = 60_000;
+
+const CACHE_WRITE_MAX_INTERVAL_MS = 5000;
+
+const CACHE_WRITE_DEBOUNCE_MS = 400;
+
+const CATCHUP_MIN_INTERVAL_MS = 1500;
 
 /**
  * How long a `focusedMessage` stays "set" before it auto-clears, in ms. The
@@ -78,6 +91,9 @@ export type ChannelContextValue = {
 	initialLoading: Accessor<boolean>;
 	error: Accessor<ColibriError | undefined>;
 	loadOlder: () => Promise<void>;
+
+	snapshotAge: Accessor<number | undefined>;
+	hydratedFromNetwork: Accessor<boolean>;
 
 	/**
 	 * The message the user is currently composing a reply to, or `undefined`.
@@ -245,6 +261,10 @@ export const ChannelContextProvider: ParentComponent<{
 	);
 	const [readCursorResolved, setReadCursorResolved] = createSignal(false);
 	const [initialUnseen, setInitialUnseen] = createSignal<string[]>([]);
+	const [snapshotAge, setSnapshotAge] = createSignal<number | undefined>(
+		undefined,
+	);
+	const [hydratedFromNetwork, setHydratedFromNetwork] = createSignal(false);
 
 	// Reply / edit / focus state. Configured with `equals: false` so that
 	// re-asserting the same message (e.g. clicking "Reply" on the same row
@@ -279,8 +299,11 @@ export const ChannelContextProvider: ParentComponent<{
 	// `inflight` pattern in the old Astro `useMessageHistory` hook).
 	let inflight = false;
 
+	let lastViewAt = 0;
+
 	const reset = () => {
 		inflight = false;
+		lastViewAt = 0;
 		reactionRkeyCache.clear();
 		batch(() => {
 			setMessages([]);
@@ -292,6 +315,8 @@ export const ChannelContextProvider: ParentComponent<{
 			setReadCursorUri(undefined);
 			setReadCursorResolved(false);
 			setInitialUnseen([]);
+			setSnapshotAge(undefined);
+			setHydratedFromNetwork(false);
 		});
 	};
 
@@ -362,24 +387,12 @@ export const ChannelContextProvider: ParentComponent<{
 		inflight = true;
 		setLoadingOlder(true);
 
-		if (cacheEnabled()) {
-			const cached = await readMessages(ns(), uri);
-			if (cached && uri === channelUri() && messages().length === 0) {
-				batch(() => {
-					setMessages(cached.messages);
-					const oldest = cached.messages[0];
-					if (oldest) setCursor(rkeyOf(oldest.uri));
-					setReadCursorUri(cached.readCursor);
-					setInitialLoading(false);
-				});
-			}
-		}
-
 		try {
-			const view = await user.xrpc.social.colibri.channel.getChannelView(
-				uri,
-				PAGE_SIZE,
-			);
+			const primed = takeChannelView(uri);
+			if (primed) markBoot("prefetch:consumed");
+			const view =
+				(await primed) ??
+				(await user.xrpc.social.colibri.channel.getChannelView(uri, PAGE_SIZE));
 
 			if (uri !== channelUri()) return;
 
@@ -391,15 +404,21 @@ export const ChannelContextProvider: ParentComponent<{
 			const channel = view.data;
 			const ordered = [...(channel?.messages ?? [])].reverse();
 
+			const stillPending = messages().filter(
+				(m) => "hash" in m && !ordered.some((o) => o.uri === m.uri),
+			);
+
 			batch(() => {
 				setError(undefined);
-				setMessages(ordered);
+				setMessages([...ordered, ...stillPending]);
 				const oldest = ordered[0];
 				if (oldest) setCursor(rkeyOf(oldest.uri));
 				if (ordered.length < PAGE_SIZE) setHasMore(false);
 				setReadCursorUri(channel?.readCursor?.cursor);
 				setInitialUnseen((channel?.unseen ?? []).map((n) => n.messageUri));
+				setHydratedFromNetwork(true);
 			});
+			lastViewAt = Date.now();
 		} catch (err) {
 			const failure = classifyThrown(err, { method: "channel.getChannelView" });
 			log.error("loadInitial failed", { code: failure.code });
@@ -414,42 +433,103 @@ export const ChannelContextProvider: ParentComponent<{
 		}
 	};
 
+	let cacheWriteTimer: ReturnType<typeof setTimeout> | undefined;
+	let pendingSnapshot:
+		| { ns: string; uri: string; snap: MessagesSnapshot }
+		| undefined;
+	let lastCacheWriteAt = 0;
+
+	const flushSnapshot = () => {
+		if (cacheWriteTimer) {
+			clearTimeout(cacheWriteTimer);
+			cacheWriteTimer = undefined;
+		}
+		const queued = pendingSnapshot;
+		if (!queued) return;
+		pendingSnapshot = undefined;
+		lastCacheWriteAt = Date.now();
+		void writeMessages(queued.ns, queued.uri, queued.snap);
+	};
+
 	// Reset state and seed the first page whenever the channel URI changes
 	// (including the initial mount). `on` makes the dependency explicit.
 	createEffect(
 		on(channelUri, (uri) => {
+			flushSnapshot();
+			registerOpenChannel(uri);
 			if (!uri) return;
 			reset();
 			loadInitial();
 		}),
 	);
+	onCleanup(() => registerOpenChannel(undefined));
 
 	createEffect(() => {
 		if (!initialLoading()) markBoot("channel:firstPage");
 	});
 
-	let cacheWriteTimer: ReturnType<typeof setTimeout> | undefined;
+	createEffect(
+		on(channelUri, async (uri) => {
+			if (!cacheEnabled() || !uri) return;
+			const cached = await readMessages(ns(), uri);
+			if (!cached) return;
+			const age = Date.now() - cached.ts;
+			if (age > MESSAGES_HARD_TTL_MS) return;
+			if (uri !== channelUri() || hydratedFromNetwork()) return;
+			if (messages().length > 0) return;
+			batch(() => {
+				setMessages(cached.messages);
+				const oldest = cached.messages[0];
+				if (oldest) setCursor(rkeyOf(oldest.uri));
+				setReadCursorUri(cached.readCursor);
+				setSnapshotAge(age);
+				setInitialLoading(false);
+				markBoot("cache:paint");
+			});
+		}),
+	);
+
 	createEffect(() => {
 		const uri = channelUri();
 		const confirmed = messages().filter(
 			(m) => !("hash" in m) && m.uri.startsWith("at://"),
 		);
-		if (!cacheEnabled() || !uri || initialLoading() || confirmed.length === 0) {
+		if (
+			!cacheEnabled() ||
+			!uri ||
+			!hydratedFromNetwork() ||
+			confirmed.length === 0
+		) {
 			return;
 		}
-		const tail = confirmed.slice(-PAGE_SIZE);
-		const readCursor = readCursorUri();
-		if (cacheWriteTimer) clearTimeout(cacheWriteTimer);
-		cacheWriteTimer = setTimeout(() => {
-			void writeMessages(ns(), uri, {
-				messages: tail,
-				readCursor,
+		pendingSnapshot = {
+			ns: ns(),
+			uri,
+			snap: {
+				messages: confirmed.slice(-PAGE_SIZE),
+				readCursor: readCursorUri(),
 				ts: Date.now(),
-			});
-		}, 1000);
+			},
+		};
+		if (Date.now() - lastCacheWriteAt >= CACHE_WRITE_MAX_INTERVAL_MS) {
+			flushSnapshot();
+			return;
+		}
+		if (cacheWriteTimer) clearTimeout(cacheWriteTimer);
+		cacheWriteTimer = setTimeout(flushSnapshot, CACHE_WRITE_DEBOUNCE_MS);
+	});
+
+	const onHidden = () => {
+		if (document.visibilityState === "hidden") flushSnapshot();
+	};
+	onMount(() => {
+		document.addEventListener("visibilitychange", onHidden);
+		window.addEventListener("pagehide", flushSnapshot);
 	});
 	onCleanup(() => {
-		if (cacheWriteTimer) clearTimeout(cacheWriteTimer);
+		document.removeEventListener("visibilitychange", onHidden);
+		window.removeEventListener("pagehide", flushSnapshot);
+		flushSnapshot();
 	});
 
 	const clearReplyingTo = () => setReplyingTo(undefined);
@@ -832,6 +912,7 @@ export const ChannelContextProvider: ParentComponent<{
 	const catchUp = async (): Promise<void> => {
 		const uri = channelUri();
 		if (!uri || initialLoading() || inflight) return;
+		if (Date.now() - lastViewAt < CATCHUP_MIN_INTERVAL_MS) return;
 
 		inflight = true;
 		try {
@@ -860,7 +941,9 @@ export const ChannelContextProvider: ParentComponent<{
 				}
 				setReadCursorUri(channel?.readCursor?.cursor);
 				setInitialUnseen((channel?.unseen ?? []).map((n) => n.messageUri));
+				setHydratedFromNetwork(true);
 			});
+			lastViewAt = Date.now();
 		} catch (err) {
 			log.error("catchUp failed", {
 				code: classifyThrown(err).code,
@@ -870,13 +953,14 @@ export const ChannelContextProvider: ParentComponent<{
 		}
 	};
 
-	let sawConnected = false;
-	createEffect(() => {
-		const isConnected = socket.connected();
-		if (!isConnected) return;
-		if (sawConnected) void catchUp();
-		sawConnected = true;
-	});
+	createEffect(
+		on(
+			() => socket.connected(),
+			(isConnected) => {
+				if (isConnected) void catchUp();
+			},
+		),
+	);
 
 	const onVisible = () => {
 		if (document.visibilityState === "visible") void catchUp();
@@ -957,6 +1041,8 @@ export const ChannelContextProvider: ParentComponent<{
 		initialLoading,
 		error,
 		loadOlder,
+		snapshotAge,
+		hydratedFromNetwork,
 		replyingTo,
 		setReplyingTo,
 		clearReplyingTo,

--- a/packages/client/src/contexts/User.tsx
+++ b/packages/client/src/contexts/User.tsx
@@ -44,7 +44,7 @@ type User =
 			atproto: {
 				client: BrowserOAuthClient;
 				agent: Agent;
-				pdsHost: string;
+				pdsHost: string | undefined;
 			};
 			communities: Array<Community>;
 			xrpc: XrpcClient;

--- a/packages/client/src/layouts/AppLayout.tsx
+++ b/packages/client/src/layouts/AppLayout.tsx
@@ -33,6 +33,7 @@ import { AppReconnectingIndicator } from "../components/app/AppReconnectingIndic
 import { CommunityCreationModal } from "../components/app/CommunityCreationModal";
 import { CommunityContextMenu } from "../components/app/community/CommunityContextMenu";
 import { PENDING_INVITE_KEY } from "../components/app/community/invite-storage";
+import { MessageSnapshotWriter } from "../components/app/MessageSnapshotWriter";
 import { NativeNotifications } from "../components/app/NativeNotifications";
 import { NotificationPromptDialog } from "../components/app/onboarding/NotificationPromptDialog";
 import { ReleaseNotesModal } from "../components/app/ReleaseNotes";
@@ -555,6 +556,7 @@ const AppLayout: ParentComponent = (props) => {
 			<VoiceOverlay />
 			<AppReconnectingIndicator />
 			<ReleaseNotesModal />
+			<MessageSnapshotWriter />
 		</div>
 	);
 };

--- a/packages/client/src/layouts/ChannelLayout.tsx
+++ b/packages/client/src/layouts/ChannelLayout.tsx
@@ -38,7 +38,11 @@ import {
 	TooltipPortal,
 	TooltipTrigger,
 } from "../components/ui/Tooltip";
-import { ChannelContextProvider, useChannelContext } from "../contexts/Channel";
+import {
+	ChannelContextProvider,
+	MESSAGES_STALE_HINT_MS,
+	useChannelContext,
+} from "../contexts/Channel";
 import { useCommunityContext } from "../contexts/Community";
 import { useMutes } from "../contexts/Mutes";
 import { isSameChannelUri, useNotifications } from "../contexts/Notifications";
@@ -885,6 +889,17 @@ const ChannelLayout: ParentComponent = (props) => {
 										>
 											<div class="w-full text-center py-4 text-sm text-muted-foreground">
 												Loading messages...
+											</div>
+										</Show>
+
+										<Show
+											when={
+												!channel.hydratedFromNetwork() &&
+												(channel.snapshotAge() ?? 0) > MESSAGES_STALE_HINT_MS
+											}
+										>
+											<div class="w-full text-center py-1.5 text-xs text-muted-foreground">
+												Catching up...
 											</div>
 										</Show>
 

--- a/packages/client/src/layouts/ChannelLayout.tsx
+++ b/packages/client/src/layouts/ChannelLayout.tsx
@@ -22,6 +22,7 @@ import ChatCircleDotsIcon from "~icons/ph/chat-circle-dots";
 import UsersIcon from "~icons/ph/users";
 import UsersIconFill from "~icons/ph/users-fill";
 import XIcon from "~icons/ph/x";
+import { isSnapshotStale } from "../atproto/cache/messages-snapshot";
 import type { Message as MessageData } from "../atproto/xrpc/social/colibri/channel/listMessages";
 import { Message } from "../components/app/channel/message/Message";
 import { ChatGuidelinesModal } from "../components/app/community/ChatGuidelinesModal";
@@ -38,11 +39,7 @@ import {
 	TooltipPortal,
 	TooltipTrigger,
 } from "../components/ui/Tooltip";
-import {
-	ChannelContextProvider,
-	MESSAGES_STALE_HINT_MS,
-	useChannelContext,
-} from "../contexts/Channel";
+import { ChannelContextProvider, useChannelContext } from "../contexts/Channel";
 import { useCommunityContext } from "../contexts/Community";
 import { useMutes } from "../contexts/Mutes";
 import { isSameChannelUri, useNotifications } from "../contexts/Notifications";
@@ -895,7 +892,7 @@ const ChannelLayout: ParentComponent = (props) => {
 										<Show
 											when={
 												!channel.hydratedFromNetwork() &&
-												(channel.snapshotAge() ?? 0) > MESSAGES_STALE_HINT_MS
+												isSnapshotStale(channel.snapshotAge())
 											}
 										>
 											<div class="w-full text-center py-1.5 text-xs text-muted-foreground">

--- a/packages/client/src/utils/last-viewed-channel.ts
+++ b/packages/client/src/utils/last-viewed-channel.ts
@@ -1,0 +1,21 @@
+const COMMUNITY_SEGMENT = /^\/app\/c\/([^/]+)/;
+
+export const lastViewedChannelPath = (pathname: string): string | undefined => {
+	const segment = COMMUNITY_SEGMENT.exec(pathname)?.[1];
+	if (!segment) return undefined;
+	let raw: string | null = null;
+	try {
+		raw = localStorage.getItem(`${segment}:last-viewed`);
+	} catch {
+		return undefined;
+	}
+	if (!raw) return undefined;
+	try {
+		const channel = JSON.parse(raw) as { uri: string; type: string };
+		const identifier = channel.uri.split("/").pop();
+		if (!identifier) return undefined;
+		return `/app/c/${segment}/${channel.type}/${identifier}`;
+	} catch {
+		return undefined;
+	}
+};

--- a/packages/client/src/utils/mobile-pane.ts
+++ b/packages/client/src/utils/mobile-pane.ts
@@ -7,24 +7,9 @@ import {
 } from "@solidjs/router";
 import { batch, createEffect, createSignal } from "solid-js";
 import createMediaQuery from "./create-media-query";
+import { lastViewedChannelPath } from "./last-viewed-channel";
 
 const CHANNEL_PATH = /^\/app\/c\/[^/]+\/[^/]+\/[^/]+/;
-const COMMUNITY_SEGMENT = /^\/app\/c\/([^/]+)/;
-
-const lastViewedChannelPath = (pathname: string): string | undefined => {
-	const segment = COMMUNITY_SEGMENT.exec(pathname)?.[1];
-	if (!segment) return undefined;
-	const raw = localStorage.getItem(`${segment}:last-viewed`);
-	if (!raw) return undefined;
-	try {
-		const channel = JSON.parse(raw) as { uri: string; type: string };
-		const identifier = channel.uri.split("/").pop();
-		if (!identifier) return undefined;
-		return `/app/c/${segment}/${channel.type}/${identifier}`;
-	} catch {
-		return undefined;
-	}
-};
 
 export type Pane = "nav" | "chat" | "members";
 

--- a/packages/lib/tsconfig.tsbuildinfo
+++ b/packages/lib/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"version":"7.0.0-dev.20260627.2","root":["./src/atproto.ts","./src/events.ts","./src/facets.ts","./src/index.ts","./src/markdown.ts","./src/shared.ts","./src/xrpc/social.colibri/actor/getdata.ts","./src/xrpc/social.colibri/actor/listcommunities.ts"]}

--- a/packages/standard-renderer/tsconfig.tsbuildinfo
+++ b/packages/standard-renderer/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"version":"7.0.0-dev.20260627.2","root":["./src/blob.ts","./src/document.ts","./src/index.ts","./src/richtext.ts","./src/types.ts"]}

--- a/packages/wrapper/scripts/build-macos-direct.sh
+++ b/packages/wrapper/scripts/build-macos-direct.sh
@@ -6,18 +6,122 @@ cd "$WRAPPER_DIR"
 
 APP_SIGNING_IDENTITY="${APPLE_APP_SIGNING_IDENTITY:-Developer ID Application: Louis Escher (8V8SWK3942)}"
 
-BUNDLE_DIR="$WRAPPER_DIR/src-tauri/target/universal-apple-darwin/release/bundle/macos"
+TARGET_DIR="$WRAPPER_DIR/src-tauri/target/universal-apple-darwin/release/bundle"
+BUNDLE_DIR="$TARGET_DIR/macos"
+DMG_DIR="$TARGET_DIR/dmg"
 APP_PATH="$BUNDLE_DIR/Colibri Social.app"
+ICON_SOURCE="$WRAPPER_DIR/src-tauri/icons/Colibri.icon"
+ENTITLEMENTS="$WRAPPER_DIR/src-tauri/Entitlements.plist"
+
+ICONLESS_CONFIG='{"bundle":{"icon":["icons/32x32.png","icons/128x128.png","icons/128x128@2x.png","icons/icon.icns","icons/icon.ico"]}}'
+
+APP_VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+DMG_NAME="Colibri Social_${APP_VERSION}_universal.dmg"
 
 rm -rf "$APP_PATH"
 
+set +e
 APPLE_SIGNING_IDENTITY="$APP_SIGNING_IDENTITY" node scripts/tauri.mjs build \
-	--target universal-apple-darwin
+	--target universal-apple-darwin --bundles app --config "$ICONLESS_CONFIG"
+TAURI_STATUS=$?
+set -e
 
-echo "--- verifying entitlements on signed .app ---"
+if [ ! -d "$APP_PATH" ]; then
+	echo "tauri build did not produce $APP_PATH (exit $TAURI_STATUS)" >&2
+	exit 1
+fi
+
+if [ "$TAURI_STATUS" -ne 0 ]; then
+	echo "tauri build exited $TAURI_STATUS after bundling the app; continuing." >&2
+	echo "this is expected without TAURI_SIGNING_PRIVATE_KEY, which only signs the updater artifact." >&2
+fi
+
+echo "--- compiling Icon Composer asset catalog ---"
+CAR_DIR="$(mktemp -d)"
+trap 'rm -rf "$CAR_DIR"' EXIT
+cp -R "$ICON_SOURCE" "$CAR_DIR/Icon.icon"
+mkdir -p "$CAR_DIR/out"
+actool "$CAR_DIR/Icon.icon" \
+	--compile "$CAR_DIR/out" \
+	--app-icon Icon \
+	--include-all-app-icons \
+	--output-partial-info-plist "$CAR_DIR/out/partial.plist" \
+	--platform macosx \
+	--target-device mac \
+	--minimum-deployment-target 26.0 \
+	--errors --warnings
+
+if [ ! -f "$CAR_DIR/out/Assets.car" ]; then
+	echo "actool did not produce an Assets.car" >&2
+	exit 1
+fi
+
+cp "$CAR_DIR/out/Assets.car" "$APP_PATH/Contents/Resources/Assets.car"
+/usr/libexec/PlistBuddy -c "Add :CFBundleIconName string Icon" "$APP_PATH/Contents/Info.plist" 2>/dev/null \
+	|| /usr/libexec/PlistBuddy -c "Set :CFBundleIconName Icon" "$APP_PATH/Contents/Info.plist"
+
+echo "--- re-signing after asset injection ---"
+codesign --force --sign "$APP_SIGNING_IDENTITY" \
+	--entitlements "$ENTITLEMENTS" \
+	--options runtime \
+	--timestamp \
+	"$APP_PATH"
+
+echo "--- rebuilding dmg from the signed app ---"
+detach_stale_volumes() {
+	for volume in /Volumes/dmg.*; do
+		[ -d "$volume" ] || continue
+		hdiutil detach "$volume" -force >/dev/null 2>&1 || true
+	done
+	rm -f "$DMG_DIR"/rw.*.dmg
+}
+
+rm -f "$DMG_DIR/$DMG_NAME"
+mkdir -p "$DMG_DIR"
+cp "$APP_PATH/Contents/Resources/icon.icns" "$DMG_DIR/icon.icns"
+
+DMG_BUILT=0
+for attempt in 1 2 3; do
+	detach_stale_volumes
+	set +e
+	(
+		cd "$DMG_DIR"
+		./bundle_dmg.sh \
+			--volname "Colibri Social" \
+			--icon "Colibri Social.app" 180 170 \
+			--app-drop-link 480 170 \
+			--window-size 660 400 \
+			--hide-extension "Colibri Social.app" \
+			--volicon "$DMG_DIR/icon.icns" \
+			"$DMG_NAME" \
+			"$APP_PATH"
+	)
+	DMG_STATUS=$?
+	set -e
+	if [ "$DMG_STATUS" -eq 0 ] && [ -f "$DMG_DIR/$DMG_NAME" ]; then
+		DMG_BUILT=1
+		break
+	fi
+	echo "dmg attempt $attempt failed (exit $DMG_STATUS), retrying" >&2
+	sleep 3
+done
+detach_stale_volumes
+
+if [ "$DMG_BUILT" -eq 1 ]; then
+	codesign --force --sign "$APP_SIGNING_IDENTITY" --timestamp "$DMG_DIR/$DMG_NAME"
+else
+	echo "could not build the dmg; the signed .app is still valid and usable." >&2
+fi
+
+echo "--- verifying signed .app ---"
+codesign --verify --strict "$APP_PATH"
 codesign -d --entitlements :- "$APP_PATH"
 codesign -dvvv "$APP_PATH" 2>&1 | grep -E "Authority|TeamIdentifier"
+/usr/libexec/PlistBuddy -c "Print :CFBundleIconName" "$APP_PATH/Contents/Info.plist"
+test -f "$APP_PATH/Contents/Resources/Assets.car" && echo "Assets.car present"
 
 echo "Direct-distribution app ready: $APP_PATH"
-echo "Bundled installers (dmg/updater artifacts) are in: $BUNDLE_DIR/.."
+if [ "$DMG_BUILT" -eq 1 ]; then
+	echo "Disk image: $DMG_DIR/$DMG_NAME"
+fi
 echo "Remember to notarize before distributing: xcrun notarytool submit ... && xcrun stapler staple \"$APP_PATH\""


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Currently, the local message store is meant to act as a backup when the connection is lost or between loads from the appview, but the implementation is rather naive, so it sometimes looks as if the app isn't loading properly.

### 📚 Description

This PR fixes channels showing stale messages when you open the app. Busy channels never saved their history at all, so reopening one could show a conversation from days ago until the network caught up, and a message someone deleted while you were reading elsewhere would come back from the dead. 

The saved history is now kept current in the background for every channel, not just the one you have open, and anything older than a day is no longer shown as if it were current. Messages also arrive much sooner after a reload: the first page is now requested as soon as you're signed in rather than after your profile and community have both finished loading, and anything posted while the app was still starting up no longer stays hidden until you click back into the window.