### PR TITLE
fix: Facet handling inconsistencies

### DIFF
--- a/.changeset/tidy-lists-edit.md
+++ b/.changeset/tidy-lists-edit.md
@@ -1,0 +1,14 @@
+---
+"@colibri-social/lib": patch
+"@colibri-social/client": patch
+"@colibri-social/website": patch
+---
+
+Fixes formatting markers being scrambled when a message is reopened for editing. A list item that started with an inline style came back inside out (`- **Test**` turned into `**- Test**`), which also corrupted the facets once the edit was saved. Headings and subtext were affected the same way whenever the inline style covered only part of the line, and copying a styled list item to the clipboard produced the same wrong text.
+
+<!-- whatsnew
+title: Editing formatted lists
+icon: list-bullets-fill
+body: Editing a message that contains a bold or italic list item no longer scrambles the formatting.
+kind: fix
+-->

--- a/apps/website/src/content/docs/docs/specification/facets.mdx
+++ b/apps/website/src/content/docs/docs/specification/facets.mdx
@@ -156,7 +156,7 @@ Because features can overlap and even conflict, rendering follows a defined orde
 
 Before rendering, facets are normalized:
 
-- Facets that share the **exact same byte range** are merged into one, and duplicate features within a range are removed.
+- Facets that share the **exact same byte range** are merged into one, and duplicate features within a range are removed. A `quote` facet is the exception: it is kept apart from a same-range facet carrying another block feature, so that the block it contains survives the merge and can be [nested inside it](#3-one-block-wrapper-per-range).
 - Facets are sorted by `byteStart`, then `byteEnd`.
 
 ### 2. Block structure wins the outer layer
@@ -167,11 +167,13 @@ Inline features are still rendered **inside** a block's range (a heading can con
 
 ### 3. One block wrapper per range
 
-If a single range somehow carries more than one block feature, exactly one wins, in this order:
+A `quote` never competes for the wrapper, it **wraps**. A quote is rendered as the `<blockquote>` and any block sharing its range is rendered inside it, so `> # title` is a blockquote containing an `<h1>` rather than one or the other.
+
+If a single range carries more than one of the remaining block features, exactly one wins, in this order:
 
 <div class="not-content">
 
-**`list` > `codeblock` > `quote` > `heading` > `subtext`**
+**`list` > `codeblock` > `heading` > `subtext`**
 
 </div>
 

--- a/packages/lib/src/markdown.test.ts
+++ b/packages/lib/src/markdown.test.ts
@@ -16,6 +16,32 @@ const summarize = (facets: Array<ColibriRichTextFacet>): Array<string> =>
 				.join("+")}`,
 	);
 
+const buildFacet = (
+	byteStart: number,
+	byteEnd: number,
+	...features: Array<Feature>
+): ColibriRichTextFacet => ({
+	$type: "social.colibri.richtext.facet",
+	index: {
+		$type: "app.bsky.richtext.facet#byteSlice",
+		byteStart,
+		byteEnd,
+	},
+	features,
+});
+
+const BOLD: Feature = { $type: "social.colibri.richtext.facet#bold" };
+const QUOTE: Feature = { $type: "social.colibri.richtext.facet#quote" };
+const CODEBLOCK: Feature = { $type: "social.colibri.richtext.facet#codeblock" };
+const heading = (level: number): Feature => ({
+	$type: "social.colibri.richtext.facet#heading",
+	level,
+});
+const list = (ordered: boolean): Feature => ({
+	$type: "social.colibri.richtext.facet#list",
+	ordered,
+});
+
 const sliceFacet = (text: string, facet: ColibriRichTextFacet): string =>
 	new TextDecoder().decode(
 		new TextEncoder()
@@ -186,6 +212,71 @@ describe("facetsToSource", () => {
 	});
 });
 
+describe("block prefixes", () => {
+	it("puts a heading marker outside an inline mark starting at the same offset", () => {
+		expect(
+			facetsToSource("x", [
+				buildFacet(0, 1, BOLD),
+				buildFacet(0, 1, heading(1)),
+			]).source,
+		).toBe("# **x**");
+	});
+
+	it("ignores feature order within a merged facet", () => {
+		expect(
+			facetsToSource("x", [buildFacet(0, 1, BOLD, heading(1))]).source,
+		).toBe("# **x**");
+		expect(
+			facetsToSource("x", [buildFacet(0, 1, BOLD, list(false))]).source,
+		).toBe("- **x**");
+	});
+
+	it("emits one marker per kind when a range carries two of the same", () => {
+		expect(
+			facetsToSource("x", [
+				buildFacet(0, 1, list(false)),
+				buildFacet(0, 1, list(true)),
+			]).source,
+		).toBe("- x");
+		expect(
+			facetsToSource("x", [
+				buildFacet(0, 1, heading(1)),
+				buildFacet(0, 1, heading(2)),
+			]).source,
+		).toBe("# x");
+	});
+
+	it("does not spend an ordered number on a discarded marker", () => {
+		expect(
+			facetsToSource("x\ny", [
+				buildFacet(0, 1, list(false)),
+				buildFacet(0, 1, list(true)),
+				buildFacet(2, 3, list(true)),
+			]).source,
+		).toBe("- x\n1. y");
+	});
+
+	it("drops a prefix colliding with a fence rather than fencing the text twice", () => {
+		expect(
+			facetsToSource("code", [
+				buildFacet(0, 4, list(false)),
+				buildFacet(0, 4, CODEBLOCK),
+			]).source,
+		).toBe("```\ncode\n```");
+	});
+
+	it("nests a quote, list, heading and inline mark on one range", () => {
+		expect(
+			facetsToSource("x", [
+				buildFacet(0, 1, QUOTE),
+				buildFacet(0, 1, list(false)),
+				buildFacet(0, 1, heading(1)),
+				buildFacet(0, 1, BOLD),
+			]).source,
+		).toBe("> - # **x**");
+	});
+});
+
 describe("round trip", () => {
 	const cases = [
 		"> one",
@@ -214,6 +305,30 @@ describe("round trip", () => {
 		"plain text",
 		"> one\n> two\nplain\n> three",
 		"> ```js\n> a\n> b\n> ```\nafter",
+		"- **Test**",
+		"- *i*",
+		"- `c`",
+		"- [x](https://e.com)",
+		"- ||sp||",
+		"- ~~gone~~",
+		"- a **b**",
+		"- # head",
+		"- ### deep",
+		"- # **x** y",
+		"- **a**\nplain\n- **b**",
+		"1. **a**\n2. **b**",
+		"1. # h",
+		"> - `c`",
+		"> - # **x**",
+		"> 1. **a**\n> 2. **b**",
+		"# **x** y",
+		"-# **x** y",
+		"## `c` tail",
+		"# [a](https://x.y) z",
+		"- -# small",
+		"-# - x",
+		"- x\n  -# y",
+		"- ```\ncode\n```",
 	];
 
 	it.each(cases)("is stable for %j", (source) => {

--- a/packages/lib/src/markdown.ts
+++ b/packages/lib/src/markdown.ts
@@ -575,6 +575,12 @@ export interface SourceWithAtoms {
 const featureKind = (feature: Feature): string =>
 	(feature.$type ?? "").split("#")[1] ?? "";
 
+interface BlockPrefix {
+	list?: string;
+	heading?: string;
+	subtext?: string;
+}
+
 /**
  * The inverse of {@link parseMarkdown}: rebuilds raw markdown source from stored
  * clean text + facets, re-injecting the literal syntax markers so the editor can
@@ -605,6 +611,19 @@ export const facetsToSource = (
 		if (arr) arr.push(value);
 		else map.set(index, [value]);
 	};
+	const blockPrefixAt = new Map<number, BlockPrefix>();
+	const setPrefix = (
+		index: number,
+		kind: keyof BlockPrefix,
+		value: string,
+	): void => {
+		const prefix = blockPrefixAt.get(index);
+		if (!prefix) {
+			blockPrefixAt.set(index, { [kind]: value });
+		} else if (prefix[kind] === undefined) {
+			prefix[kind] = value;
+		}
+	};
 	const codeblocks: Array<[number, number, string]> = [];
 	const atomStarts = new Map<number, { end: number; feature: Feature }>();
 	const listFacets: Array<{ start: number; end: number; ordered: boolean }> =
@@ -633,9 +652,9 @@ export const facetsToSource = (
 				}
 			} else if (kind === "heading") {
 				const level = "level" in feature ? Number(feature.level) || 1 : 1;
-				addMarker(opensAt, start, `${"#".repeat(Math.min(3, level))} `);
+				setPrefix(start, "heading", `${"#".repeat(Math.min(3, level))} `);
 			} else if (kind === "subtext") {
-				addMarker(opensAt, start, "-# ");
+				setPrefix(start, "subtext", "-# ");
 			} else if (kind === "list") {
 				listFacets.push({
 					start,
@@ -653,15 +672,18 @@ export const facetsToSource = (
 	listFacets.sort((a, b) => a.start - b.start);
 	let counter = 0;
 	let prevEnd = -2;
+	let prevStart = -1;
 	for (const lf of listFacets) {
+		if (lf.start === prevStart) continue;
 		if (!(lf.ordered && lf.start === prevEnd + 1)) counter = 0;
 		if (lf.ordered) {
 			counter++;
-			addMarker(opensAt, lf.start, `${counter}. `);
+			setPrefix(lf.start, "list", `${counter}. `);
 		} else {
-			addMarker(opensAt, lf.start, "- ");
+			setPrefix(lf.start, "list", "- ");
 		}
 		prevEnd = lf.end;
+		prevStart = lf.start;
 	}
 
 	codeblocks.sort((a, b) => a[0] - b[0]);
@@ -713,6 +735,13 @@ export const facetsToSource = (
 			out += `\n${prefix}\`\`\``;
 			i = Math.max(fence[1], i + 1);
 			continue;
+		}
+
+		const blockPrefix = blockPrefixAt.get(i);
+		if (blockPrefix) {
+			out += blockPrefix.list ?? "";
+			out += blockPrefix.heading ?? "";
+			out += blockPrefix.subtext ?? "";
 		}
 
 		const openers = opensAt.get(i);


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Currently, inputting markdown in a list, sending that message, then editing that message results in incorrect formatting being parsed and displayed in the editor.

### 📚 Description

This PR improves the facet -> markdown rendering and fixes issues that were causing this