### PR TITLE
feat: WebP support for community images

### DIFF
--- a/.changeset/webp-community-images.md
+++ b/.changeset/webp-community-images.md
@@ -1,0 +1,12 @@
+---
+"@colibri-social/website": minor
+---
+
+Accept WebP community pictures and banners. The `social.colibri.community` lexicon now lists `image/webp` alongside JPEG, PNG and GIF, matching what profile avatars and banners already allowed.
+
+<!-- whatsnew
+title: WebP images
+icon: image-fill
+body: Community pictures and banners now accept WebP images.
+kind: feature
+-->

--- a/apps/website/src/content/docs/docs/specification/appview.mdx
+++ b/apps/website/src/content/docs/docs/specification/appview.mdx
@@ -735,7 +735,7 @@ Mints a new community DID on the AppView's own PDS and bootstraps a fully popula
 - `social.colibri.role`: an `"Owner"` role with every permission and `protected: true` so role-management endpoints refuse to delete it
 - `social.colibri.member`: `subject` = authenticated caller, holding the Owner role
 
-The caller ends up as an owner-equivalent member of the new community. The community picture and banner are uploaded as `multipart/form-data` parts named `picture` and `banner`, each carrying its own `Content-Type`. Every supplied image is validated against the allowed MIME types (`image/jpeg`, `image/png`, `image/gif`) and capped at 10 MiB before being uploaded to the community's PDS. A missing part means that image is not set.
+The caller ends up as an owner-equivalent member of the new community. The community picture and banner are uploaded as `multipart/form-data` parts named `picture` and `banner`, each carrying its own `Content-Type`. Every supplied image is validated against the allowed MIME types (`image/jpeg`, `image/png`, `image/gif`, `image/webp`) and capped at 10 MiB before being uploaded to the community's PDS. A missing part means that image is not set.
 
 <XRPCEndpointCard
 	method="POST"

--- a/apps/website/src/utils/atproto/lexicons/generated/manifest.json
+++ b/apps/website/src/utils/atproto/lexicons/generated/manifest.json
@@ -25,7 +25,7 @@
 		"social.colibri.channel.listUnreadStatus": "5eca70dd9715d37c3b673c05f4f723a905e211106200929dbe60b6f1a9bd5709",
 		"social.colibri.channel.read": "25f668ed25eecb003687d0f832c219b68198fca8510017be2d2e9c6585b97d71",
 		"social.colibri.channel.update": "9d42a28b07f49086dbe6196dcd86565983432d93f82b307f2ccf662300502081",
-		"social.colibri.community": "3e73212f75ea83e09419d9c2a5e79ec78d0a418ad765c1c9dfb3ab6d37912490",
+		"social.colibri.community": "9b444c781363a8f2e3460f615b3b390d8689e49b4bd797ce9a806d649dc3e899",
 		"social.colibri.community.approveMembership": "1a894ab818128068908bd20415053eafcc6bf9a60f2da3cdf5d631b5b48b92ef",
 		"social.colibri.community.banUser": "3b7ed6f4ee9c106517f349e87285990ba15c6e61bd2666f5dce2e15d6fb83856",
 		"social.colibri.community.blockMessage": "c0f1aa1b3d8258a8a63227a40628f5e964abc602e2a34174f397edba36eb3e43",

--- a/apps/website/src/utils/atproto/lexicons/generated/social.colibri.community.json
+++ b/apps/website/src/utils/atproto/lexicons/generated/social.colibri.community.json
@@ -40,7 +40,8 @@
 						"accept": [
 							"image/jpeg",
 							"image/png",
-							"image/gif"
+							"image/gif",
+							"image/webp"
 						]
 					},
 					"banner": {
@@ -49,7 +50,8 @@
 						"accept": [
 							"image/jpeg",
 							"image/png",
-							"image/gif"
+							"image/gif",
+							"image/webp"
 						]
 					},
 					"categoryOrder": {

--- a/apps/website/src/utils/atproto/lexicons/records/community.ts
+++ b/apps/website/src/utils/atproto/lexicons/records/community.ts
@@ -43,13 +43,13 @@ export const communityRecordDocs: LexiconDoc[] = [
 							type: "blob",
 							description:
 								"An image for the community that will be shown to users.",
-							accept: ["image/jpeg", "image/png", "image/gif"],
+							accept: ["image/jpeg", "image/png", "image/gif", "image/webp"],
 						},
 						banner: {
 							type: "blob",
 							description:
 								"A banner for the community that will be shown to users.",
-							accept: ["image/jpeg", "image/png", "image/gif"],
+							accept: ["image/jpeg", "image/png", "image/gif", "image/webp"],
 						},
 						categoryOrder: {
 							type: "array",


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Most endpoints already supported the WebP image format, but the community image endpoints did not.

### 📚 Description

This PR updates the lexicon for the community xrpc endpoints to include WebP as a valid image type. See https://github.com/colibri-social/appview/pull/78 for the appview impl.